### PR TITLE
Tomcat integration: Store principal in session

### DIFF
--- a/cas-client-integration-tomcat-v6/src/main/java/org/jasig/cas/client/tomcat/v6/AbstractAuthenticator.java
+++ b/cas-client-integration-tomcat-v6/src/main/java/org/jasig/cas/client/tomcat/v6/AbstractAuthenticator.java
@@ -154,8 +154,7 @@ public abstract class AbstractAuthenticator extends AuthenticatorBase implements
             // Authentication sets the response headers for status and redirect if needed
 	        principal = this.delegate.authenticate(request.getRequest(), response);
             if (principal != null) {
-                request.setAuthType(getAuthenticationMethod());
-                request.setUserPrincipal(principal);
+                register(request, response, principal, getAuthenticationMethod(), null, null);
                 result = true;
             }
         } else {

--- a/cas-client-integration-tomcat-v7/src/main/java/org/jasig/cas/client/tomcat/v7/AbstractAuthenticator.java
+++ b/cas-client-integration-tomcat-v7/src/main/java/org/jasig/cas/client/tomcat/v7/AbstractAuthenticator.java
@@ -163,8 +163,7 @@ public abstract class AbstractAuthenticator extends AuthenticatorBase implements
             // Authentication sets the response headers for status and redirect if needed
 	        principal = this.delegate.authenticate(request.getRequest(), response);
             if (principal != null) {
-                request.setAuthType(getAuthenticationMethod());
-                request.setUserPrincipal(principal);
+                register(request, response, principal, getAuthenticationMethod(), null, null);
                 result = true;
             }
         } else {


### PR DESCRIPTION
With the standard container-managed auth methods (BASIC, DIGEST, FORM), once the user has authenticated, getUserPrincipal() and friends will always return the authenticated principal, regardless of whether or not a URL falls under a security-constraint.

The Soulwing CAS client, when integrated with Tomcat, also behaves this way.

When switching [Jenkins](http://jenkins-ci.org/) from Soulwing to the JA-SIG CAS client, I noticed I wasn't being logged in. After some debugging, I realized that getUserPrincipal() was only returning the principal in Jenkins's /loginEntry URL -- not for any others.

This can be easily fixed by simply calling AuthenticationBase.register(), which will take care of stuffing the principal into the request as well as the session (if it exists).
