### PR TITLE
.gitignore Eclipse's .project default output bin/ directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !/.project
 .project
 .settings
+bin
 target
 *.ipr
 *.iml


### PR DESCRIPTION
While working with Eclipse the directory keeps showing up.
