### PR TITLE
Allow AuthenticationFilter to find request stored Assertion in safe way

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/authentication/AuthenticationFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/authentication/AuthenticationFilter.java
@@ -100,7 +100,7 @@ public class AuthenticationFilter extends AbstractCasFilter {
     public final void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse, final FilterChain filterChain) throws IOException, ServletException {
         final HttpServletRequest request = (HttpServletRequest) servletRequest;
         final HttpServletResponse response = (HttpServletResponse) servletResponse;
-        final Assertion assertion = retrieveAssertionFromRequest(request);
+        final Assertion assertion = retrieveAssertion(request);
 
         if (assertion != null) {
             filterChain.doFilter(request, response);

--- a/cas-client-core/src/main/java/org/jasig/cas/client/authentication/AuthenticationFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/authentication/AuthenticationFilter.java
@@ -66,7 +66,7 @@ public class AuthenticationFilter extends AbstractCasFilter {
      * Whether to send the gateway request or not.
      */
     private boolean gateway = false;
-    
+
     private GatewayResolver gatewayStorage = new DefaultGatewayResolverImpl();
 
     protected void initInternal(final FilterConfig filterConfig) throws ServletException {
@@ -100,8 +100,7 @@ public class AuthenticationFilter extends AbstractCasFilter {
     public final void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse, final FilterChain filterChain) throws IOException, ServletException {
         final HttpServletRequest request = (HttpServletRequest) servletRequest;
         final HttpServletResponse response = (HttpServletResponse) servletResponse;
-        final HttpSession session = request.getSession(false);
-        final Assertion assertion = session != null ? (Assertion) session.getAttribute(CONST_CAS_ASSERTION) : null;
+        final Assertion assertion = retrieveAssertionFromRequest(request);
 
         if (assertion != null) {
             filterChain.doFilter(request, response);
@@ -140,7 +139,8 @@ public class AuthenticationFilter extends AbstractCasFilter {
         response.sendRedirect(urlToRedirectTo);
     }
 
-    public final void setRenew(final boolean renew) {
+
+	public final void setRenew(final boolean renew) {
         this.renew = renew;
     }
 
@@ -151,7 +151,7 @@ public class AuthenticationFilter extends AbstractCasFilter {
     public final void setCasServerLoginUrl(final String casServerLoginUrl) {
         this.casServerLoginUrl = casServerLoginUrl;
     }
-    
+
     public final void setGatewayStorage(final GatewayResolver gatewayStorage) {
     	this.gatewayStorage = gatewayStorage;
     }

--- a/cas-client-core/src/main/java/org/jasig/cas/client/authentication/AuthenticationFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/authentication/AuthenticationFilter.java
@@ -66,7 +66,7 @@ public class AuthenticationFilter extends AbstractCasFilter {
      * Whether to send the gateway request or not.
      */
     private boolean gateway = false;
-
+    
     private GatewayResolver gatewayStorage = new DefaultGatewayResolverImpl();
 
     protected void initInternal(final FilterConfig filterConfig) throws ServletException {
@@ -139,8 +139,7 @@ public class AuthenticationFilter extends AbstractCasFilter {
         response.sendRedirect(urlToRedirectTo);
     }
 
-
-	public final void setRenew(final boolean renew) {
+    public final void setRenew(final boolean renew) {
         this.renew = renew;
     }
 
@@ -151,7 +150,7 @@ public class AuthenticationFilter extends AbstractCasFilter {
     public final void setCasServerLoginUrl(final String casServerLoginUrl) {
         this.casServerLoginUrl = casServerLoginUrl;
     }
-
+    
     public final void setGatewayStorage(final GatewayResolver gatewayStorage) {
     	this.gatewayStorage = gatewayStorage;
     }

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/AbstractCasFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/AbstractCasFilter.java
@@ -56,7 +56,7 @@ public abstract class AbstractCasFilter extends AbstractConfigurationFilter {
 
     /** Defines the parameter to look for for the service. */
     private String serviceParameterName = "service";
-
+    
     /** Sets where response.encodeUrl should be called on service urls when constructed. */
     private boolean encodeServiceUrl = true;
 
@@ -141,7 +141,7 @@ public abstract class AbstractCasFilter extends AbstractConfigurationFilter {
     public final void setServiceParameterName(final String serviceParameterName) {
         this.serviceParameterName = serviceParameterName;
     }
-
+    
     public final void setEncodeServiceUrl(final boolean encodeServiceUrl) {
     	this.encodeServiceUrl = encodeServiceUrl;
     }

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/AbstractCasFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/AbstractCasFilter.java
@@ -163,7 +163,7 @@ public abstract class AbstractCasFilter extends AbstractConfigurationFilter {
      * @param request the HTTP ServletRequest. CANNOT be NULL.
      * @return the Assertion found (in request or session), null otherwise.
      */
-    protected Assertion retrieveAssertionFromRequest(HttpServletRequest request) {
+    protected Assertion retrieveAssertion(HttpServletRequest request) {
         final Object requestAssertion = request.getAttribute(CONST_CAS_ASSERTION);
         if (requestAssertion instanceof Assertion) {
             return (Assertion)requestAssertion;

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/AbstractCasFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/AbstractCasFilter.java
@@ -21,11 +21,13 @@ package org.jasig.cas.client.util;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jasig.cas.client.validation.Assertion;
 
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 /**
  *  Abstract filter that contains code that is common to all CAS filters.
@@ -54,7 +56,7 @@ public abstract class AbstractCasFilter extends AbstractConfigurationFilter {
 
     /** Defines the parameter to look for for the service. */
     private String serviceParameterName = "service";
-    
+
     /** Sets where response.encodeUrl should be called on service urls when constructed. */
     private boolean encodeServiceUrl = true;
 
@@ -139,7 +141,7 @@ public abstract class AbstractCasFilter extends AbstractConfigurationFilter {
     public final void setServiceParameterName(final String serviceParameterName) {
         this.serviceParameterName = serviceParameterName;
     }
-    
+
     public final void setEncodeServiceUrl(final boolean encodeServiceUrl) {
     	this.encodeServiceUrl = encodeServiceUrl;
     }
@@ -150,6 +152,29 @@ public abstract class AbstractCasFilter extends AbstractConfigurationFilter {
 
     public final String getServiceParameterName() {
         return this.serviceParameterName;
+    }
+
+    /**
+     * Template method to allow you to change how you retrieve the Assertion from request.
+     * <P>
+     * This implementation will look for the Assertion in the HTTPRequest attribute
+     * {@value #CONST_CAS_ASSERTION} and after that in the session.
+     *
+     * @param request the HTTP ServletRequest. CANNOT be NULL.
+     * @return the Assertion found (in request or session), null otherwise.
+     */
+    protected Assertion retrieveAssertionFromRequest(HttpServletRequest request) {
+        final Object requestAssertion = request.getAttribute(CONST_CAS_ASSERTION);
+        if (requestAssertion instanceof Assertion) {
+            return (Assertion)requestAssertion;
+        }
+
+        final HttpSession session = request.getSession(false);
+        final Object sessionAssertion = (session != null) ? session.getAttribute(CONST_CAS_ASSERTION) : null;
+        if (sessionAssertion instanceof Assertion) {
+            return (Assertion)sessionAssertion;
+        }
+        return null;
     }
 
     /**

--- a/cas-client-core/src/test/java/org/jasig/cas/client/util/CasFilterTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/util/CasFilterTests.java
@@ -1,11 +1,11 @@
 package org.jasig.cas.client.util;
 
-import org.jasig.cas.client.validation.Assertion;
-import org.jasig.cas.client.validation.AssertionImpl;
-import org.junit.Test;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.mock.web.MockHttpSession;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -14,9 +14,11 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
-import java.io.IOException;
-
-import static org.junit.Assert.*;
+import org.jasig.cas.client.validation.Assertion;
+import org.jasig.cas.client.validation.AssertionImpl;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
  * @author Scott Battaglia, Bernd Eckenfels
@@ -77,7 +79,7 @@ public final class CasFilterTests {
     }
 
     @Test
-    public void retrieveAssertionRequest() {
+    public void retrieveAssertionRequestNoSession() {
         final TestCasFilter testCasFilter = new TestCasFilter();
         final HttpServletRequest request = new MockHttpServletRequest();
         final Assertion testAssertion = new AssertionImpl("testprincipal");
@@ -85,8 +87,27 @@ public final class CasFilterTests {
         request.setAttribute(AbstractCasFilter.CONST_CAS_ASSERTION, testAssertion);
 
         final Object value = testCasFilter.retrieveAssertion(request);
+
         assertSame(testAssertion, value);
+        assertNull(request.getSession(false));
     }
+
+    @Test
+    public void retrieveAssertionRequestEmptySession() {
+        final TestCasFilter testCasFilter = new TestCasFilter();
+        final HttpServletRequest request = new MockHttpServletRequest();
+        final Assertion testAssertion = new AssertionImpl("testprincipal");
+        final HttpSession session = request.getSession(true);
+        assertNotNull("The MockHTTPServlerRequest does not work like a real session.", session);
+
+        request.setAttribute(AbstractCasFilter.CONST_CAS_ASSERTION, testAssertion);
+
+        final Object value = testCasFilter.retrieveAssertion(request);
+        assertSame(testAssertion, value);
+        assertSame(session, request.getSession());
+        // Do we want to allow/forbid/require that assertion is propagated to session
+    }
+
 
     /** Make sure AbstractCasFilter#retrieveAssertion() prefers request */
     @Test
@@ -105,7 +126,7 @@ public final class CasFilterTests {
         assertSame(testAssertionRequest, value);
     }
 
-    /** Make sure AbstractCasFilter#retrieveAssertion() prefers request */
+    /** Make sure AbstractCasFilter#retrieveAssertion() ignores casting problems. */
     @Test
     public void retrieveAssertionIllegalObjectsIgnored() {
         final TestCasFilter testCasFilter = new TestCasFilter();

--- a/cas-client-core/src/test/java/org/jasig/cas/client/util/CasFilterTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/util/CasFilterTests.java
@@ -1,20 +1,25 @@
 package org.jasig.cas.client.util;
 
+import org.jasig.cas.client.validation.Assertion;
+import org.jasig.cas.client.validation.AssertionImpl;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
 import java.io.IOException;
 
 import static org.junit.Assert.*;
 
 /**
- * @author Scott Battaglia
- * @version $Revision$ $Date$
+ * @author Scott Battaglia, Bernd Eckenfels
  * @since 3.2.1
  */
 public final class CasFilterTests {
@@ -44,5 +49,74 @@ public final class CasFilterTests {
         public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
             // nothing to do
         }
+    }
+
+    @Test
+    public void retrieveAssertionNull() {
+        final TestCasFilter testCasFilter = new TestCasFilter();
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+
+        Object value = testCasFilter.retrieveAssertion(request);
+
+        assertNull(value);
+        assertNull(request.getSession(false));
+    }
+
+    @Test
+    public void retrieveAssertionSession() {
+        final TestCasFilter testCasFilter = new TestCasFilter();
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final Assertion testAssertion = new AssertionImpl("testprincipal");
+        final HttpSession session = request.getSession(true);
+        assertNotNull("The MockHTTPServlerRequest does not work like a real session.", session);
+
+        session.setAttribute(AbstractCasFilter.CONST_CAS_ASSERTION, testAssertion);
+
+        final Object value = testCasFilter.retrieveAssertion(request);
+        assertSame(testAssertion, value);
+    }
+
+    @Test
+    public void retrieveAssertionRequest() {
+        final TestCasFilter testCasFilter = new TestCasFilter();
+        final HttpServletRequest request = new MockHttpServletRequest();
+        final Assertion testAssertion = new AssertionImpl("testprincipal");
+
+        request.setAttribute(AbstractCasFilter.CONST_CAS_ASSERTION, testAssertion);
+
+        final Object value = testCasFilter.retrieveAssertion(request);
+        assertSame(testAssertion, value);
+    }
+
+    /** Make sure AbstractCasFilter#retrieveAssertion() prefers request */
+    @Test
+    public void retrieveAssertionRequestOrSession() {
+        final TestCasFilter testCasFilter = new TestCasFilter();
+        final HttpServletRequest request = new MockHttpServletRequest();
+        final Assertion testAssertionSession = new AssertionImpl("testprincipalSession");
+        final Assertion testAssertionRequest = new AssertionImpl("testprincipalRequest");
+        final HttpSession session = request.getSession(true);
+        assertNotNull("The MockHTTPServlerRequest does not work like a real session.", session);
+
+        session.setAttribute(AbstractCasFilter.CONST_CAS_ASSERTION, testAssertionSession);
+        request.setAttribute(AbstractCasFilter.CONST_CAS_ASSERTION, testAssertionRequest);
+
+        final Object value = testCasFilter.retrieveAssertion(request);
+        assertSame(testAssertionRequest, value);
+    }
+
+    /** Make sure AbstractCasFilter#retrieveAssertion() prefers request */
+    @Test
+    public void retrieveAssertionIllegalObjectsIgnored() {
+        final TestCasFilter testCasFilter = new TestCasFilter();
+        final HttpServletRequest request = new MockHttpServletRequest();
+        final HttpSession session = request.getSession(true);
+        assertNotNull("The MockHTTPServlerRequest does not work like a real session.", session);
+
+        session.setAttribute(AbstractCasFilter.CONST_CAS_ASSERTION, "wrong session object");
+        request.setAttribute(AbstractCasFilter.CONST_CAS_ASSERTION, "wrong request object");
+
+        final Object value = testCasFilter.retrieveAssertion(request);
+        assertNull(value);
     }
 }


### PR DESCRIPTION
This will enable the Authentication Filter to actually accept sessionless Authentications. It will also make sure it only allows the right Attribute class (avoid ClassCastExceptions). It introduces quite a few new testcases and assertions. It adds a template method to actually get the Assertion from the HTTPRequest.
