### PR TITLE
Fix for Confluence 4.x compatibility

### DIFF
--- a/cas-client-integration-atlassian/pom.xml
+++ b/cas-client-integration-atlassian/pom.xml
@@ -48,7 +48,7 @@
       <!-- https://maven.atlassian.com/content/groups/m1/com.atlassian.confluence/jars/ -->
       <groupId>com.atlassian.confluence</groupId>
       <artifactId>confluence</artifactId>
-      <version>3.5</version>
+      <version>4.2.8</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/atlassian/ConfluenceCasAuthenticator.java
+++ b/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/atlassian/ConfluenceCasAuthenticator.java
@@ -49,10 +49,10 @@ public final class ConfluenceCasAuthenticator extends ConfluenceAuthenticator {
     public Principal getUser(final HttpServletRequest request, final HttpServletResponse response) {
         final HttpSession session = request.getSession();
 
-        // user already exists
-        if (session.getAttribute(LOGGED_IN_KEY) != null) {
-            LOGGER.debug("Session found; user already logged in.");
-            return (Principal) session.getAttribute(LOGGED_IN_KEY);
+        Principal loggedUser = getUserFromSession(request);
+        if (loggedUser != null) {
+            // user already exists - is logged in
+            return loggedUser;
         }
 
         final Assertion assertion = (Assertion) session.getAttribute(AbstractCasFilter.CONST_CAS_ASSERTION);
@@ -62,8 +62,8 @@ public final class ConfluenceCasAuthenticator extends ConfluenceAuthenticator {
 
             LOGGER.debug("Logging in [{}] from CAS.", p.getName());
 
-            session.setAttribute(LOGGED_IN_KEY, p);
-            session.setAttribute(LOGGED_OUT_KEY, null);
+            putPrincipalInSessionContext(request, p);
+
             return p;
         }
 
@@ -73,13 +73,12 @@ public final class ConfluenceCasAuthenticator extends ConfluenceAuthenticator {
     public boolean logout(final HttpServletRequest request, final HttpServletResponse response) throws AuthenticatorException {
         final HttpSession session = request.getSession();
 
-        final Principal principal = (Principal) session.getAttribute(LOGGED_IN_KEY);
+        final Principal principal = getUserFromSession(request);
 
         LOGGER.debug("Logging out [{}] from CAS.", principal.getName());
 
-        session.setAttribute(LOGGED_OUT_KEY, principal);
-        session.setAttribute(LOGGED_IN_KEY, null);
         session.setAttribute(AbstractCasFilter.CONST_CAS_ASSERTION, null);
+        putPrincipalInSessionContext(request, null);
         return true;
     }
 }


### PR DESCRIPTION
The atlassian integration module is now compiled against Confluence
lib for version 4.2.8 and a small modifications have been done in
ConfluenceCasAuthenticator class, because Confluence API for custom
authenticators changed a little bit. See the problem here :
https://answers.atlassian.com/questions/75044/cas-integration-classcastexception-with-confluence-version-4-2-11
