### PR TITLE
CASC-207: Make loggers in final classes static

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/proxy/Cas20ProxyRetriever.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/proxy/Cas20ProxyRetriever.java
@@ -49,7 +49,7 @@ public final class Cas20ProxyRetriever implements ProxyRetriever {
 	  /**
      * Instance of Commons Logging.
      */
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(Cas20ProxyRetriever.class);
 
     /**
      * Url to CAS server.
@@ -84,7 +84,7 @@ public final class Cas20ProxyRetriever implements ProxyRetriever {
         final String error = XmlUtils.getTextForElement(response, "proxyFailure");
     
         if (CommonUtils.isNotEmpty(error)) {
-            logger.debug(error);
+            LOGGER.debug(error);
             return null;
         }
     

--- a/cas-client-core/src/main/java/org/jasig/cas/client/proxy/ProxyGrantingTicketStorageImpl.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/proxy/ProxyGrantingTicketStorageImpl.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class ProxyGrantingTicketStorageImpl implements ProxyGrantingTicketStorage {
 	
-	private final Logger logger = LoggerFactory.getLogger(getClass());
+	private static final Logger LOGGER = LoggerFactory.getLogger(ProxyGrantingTicketStorageImpl.class);
 
     /**
      * Default timeout in milliseconds.
@@ -89,20 +89,20 @@ public final class ProxyGrantingTicketStorageImpl implements ProxyGrantingTicket
         final ProxyGrantingTicketHolder holder = this.cache.get(proxyGrantingTicketIou);
 
         if (holder == null) {
-        	logger.info("No Proxy Ticket found for [{}].", proxyGrantingTicketIou);
+        	LOGGER.info("No Proxy Ticket found for [{}].", proxyGrantingTicketIou);
             return null;
         }
 
         this.cache.remove(proxyGrantingTicketIou);
 
-        logger.debug("Returned ProxyGrantingTicket of [{}]", holder.getProxyGrantingTicket());
+        LOGGER.debug("Returned ProxyGrantingTicket of [{}]", holder.getProxyGrantingTicket());
         return holder.getProxyGrantingTicket();
     }
 
     public void save(final String proxyGrantingTicketIou, final String proxyGrantingTicket) {
         final ProxyGrantingTicketHolder holder = new ProxyGrantingTicketHolder(proxyGrantingTicket);
 
-        logger.debug("Saving ProxyGrantingTicketIOU and ProxyGrantingTicket combo: [{}, {}]", proxyGrantingTicketIou, proxyGrantingTicket);
+        LOGGER.debug("Saving ProxyGrantingTicketIOU and ProxyGrantingTicket combo: [{}, {}]", proxyGrantingTicketIou, proxyGrantingTicket);
         this.cache.put(proxyGrantingTicketIou, holder);
     }
 


### PR DESCRIPTION
Loggers in org.jasig.cas.client.proxy.Cas20ProxyRetriever and org.jasig.cas.client.proxy.ProxyGrantingTicketStorageImpl are fields, but these classes are final. Therefore, the loggers should be static, too, to avoid creating new loggers for each instance. Additionally, since these two classes are serializable, having non-transient loggers is not ideal (and can cause problems when using slf4j).
