### PR TITLE
CASC-203 Properly Parse Response to Keep Line Breaks

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
@@ -328,29 +328,28 @@ public final class CommonUtils {
             final String encoding) {
 
         HttpURLConnection conn = null;
+        InputStreamReader in = null;
         try {
             conn = factory.buildHttpURLConnection(constructedUrl.openConnection());
 
-            final BufferedReader in;
-
             if (CommonUtils.isEmpty(encoding)) {
-                in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+                in = new InputStreamReader(conn.getInputStream());
             } else {
-                in = new BufferedReader(new InputStreamReader(conn.getInputStream(), encoding));
+                in = new InputStreamReader(conn.getInputStream(), encoding);
             }
 
-            String line;
-            final StringBuilder stringBuffer = new StringBuilder(255);
-
-            while ((line = in.readLine()) != null) {
-                stringBuffer.append(line);
-                stringBuffer.append("\n");
+            final StringBuilder builder = new StringBuilder(255);
+            int byteRead;
+            while ((byteRead = in.read()) != -1) {
+                builder.append((char) byteRead);
             }
-            return stringBuffer.toString();
+
+            return builder.toString();
         } catch (final Exception e) {
             LOGGER.error(e.getMessage(), e);
             throw new RuntimeException(e);
         } finally {
+            closeQuietly(in);
             if (conn != null) {
                 conn.disconnect();
             }

--- a/cas-client-core/src/test/java/org/jasig/cas/client/util/CommonUtilsTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/util/CommonUtilsTests.java
@@ -18,9 +18,12 @@
  */
 package org.jasig.cas.client.util;
 
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import junit.framework.TestCase;
+import org.jasig.cas.client.PublicTestHttpServer;
+import org.jasig.cas.client.ssl.HttpsURLConnectionFactory;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -32,6 +35,8 @@ import org.springframework.mock.web.MockHttpServletResponse;
  * @since 3.0
  */
 public final class CommonUtilsTests extends TestCase {
+
+    private static final PublicTestHttpServer server = PublicTestHttpServer.instance(8090);
 
     public void testRedirectUrlWithParam() {
         final String loginUrl = "http://localhost:8080/login?myName=foo";
@@ -153,5 +158,13 @@ public final class CommonUtilsTests extends TestCase {
         final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null,
                 "http://www.amazon.com https://www.bestbuy.com https://www.myserver.com", "ticket", false);
         assertEquals(CONST_MY_URL, constructedUrl);
+    }
+
+    public void testGetResponseFromServer() throws Exception {
+        final String RESPONSE = "test1\r\ntest2";
+        server.content = RESPONSE.getBytes(server.encoding);
+
+        final String responsedContent = CommonUtils.getResponseFromServer(new URL("http://localhost:8090"), new HttpsURLConnectionFactory(), null);
+        assertEquals(RESPONSE, responsedContent);
     }
 }


### PR DESCRIPTION
Problem: The CAS Client uses a buffer reader which strips out the returned line breaks.
Solution: Switch to a normal input stream reader and add appropriate test.
