### PR TITLE
CASC-228 URL Encode Paramaters Passed to Server via Validate

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/validation/AbstractUrlBasedTicketValidator.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/validation/AbstractUrlBasedTicketValidator.java
@@ -110,7 +110,7 @@ public abstract class AbstractUrlBasedTicketValidator implements TicketValidator
 
         logger.debug("Placing URL parameters in map.");
         urlParameters.put("ticket", ticket);
-        urlParameters.put("service", encodeUrl(serviceUrl));
+        urlParameters.put("service", serviceUrl);
 
         if (this.renew) {
             urlParameters.put("renew", "true");
@@ -144,7 +144,8 @@ public abstract class AbstractUrlBasedTicketValidator implements TicketValidator
                 buffer.append(i++ == 0 ? "?" : "&");
                 buffer.append(key);
                 buffer.append("=");
-                buffer.append(value);
+                final String encodedValue = encodeUrl(value);
+                buffer.append(encodedValue);
             }
         }
 

--- a/cas-client-core/src/main/java/org/jasig/cas/client/validation/Cas20ServiceTicketValidator.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/validation/Cas20ServiceTicketValidator.java
@@ -70,7 +70,7 @@ public class Cas20ServiceTicketValidator extends AbstractCasProtocolUrlBasedTick
      * @param urlParameters the Map containing the existing parameters to send to the server.
      */
     protected final void populateUrlAttributeMap(final Map<String, String> urlParameters) {
-        urlParameters.put("pgtUrl", encodeUrl(this.proxyCallbackUrl));
+        urlParameters.put("pgtUrl", this.proxyCallbackUrl);
     }
 
     protected String getUrlSuffix() {

--- a/cas-client-core/src/test/java/org/jasig/cas/client/validation/Cas10TicketValidatorTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/validation/Cas10TicketValidatorTests.java
@@ -18,8 +18,7 @@
  */
 package org.jasig.cas.client.validation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import java.io.UnsupportedEncodingException;
 import org.jasig.cas.client.PublicTestHttpServer;
 import org.junit.Before;
@@ -79,5 +78,16 @@ public final class Cas10TicketValidatorTests extends AbstractTicketValidatorTest
         } catch (final TicketValidationException e) {
             // expected
         }
+    }
+
+    @Test
+    public void urlEncodedValues() {
+        final String ticket = "ST-1-owKEOtYJjg77iHcCQpkl-cas01.example.org%26%73%65%72%76%69%63%65%3d%68%74%74%70%25%33%41%25%32%46%25%32%46%31%32%37%2e%30%2e%30%2e%31%25%32%46%62%6f%72%69%6e%67%25%32%46%23";
+        final String service = "foobar";
+        final String url = this.ticketValidator.constructValidationUrl(ticket, service);
+
+        final String encodedValue = this.ticketValidator.encodeUrl(ticket);
+        assertTrue(url.contains(encodedValue));
+        assertFalse(url.contains(ticket));
     }
 }


### PR DESCRIPTION
Problem: We currently don't pass encoded values to the server, possibly resulting in parsing/extraction errors.
Solution: URL Encode all values instead of just the service url.

QA Notes: Added unit test.
