### PR TITLE
CASC-225 Restore Removed Constructor for Backwards Compatibility

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/proxy/Cas20ProxyRetriever.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/proxy/Cas20ProxyRetriever.java
@@ -55,6 +55,11 @@ public final class Cas20ProxyRetriever implements ProxyRetriever {
     /** Url connection factory to use when communicating with the server **/
     private final HttpURLConnectionFactory urlConnectionFactory;
 
+    @Deprecated
+    public Cas20ProxyRetriever(final String casServerUrl, final String encoding) {
+        this(casServerUrl, encoding, null);
+    }
+
     /**
      * Main Constructor.
      *
@@ -75,7 +80,13 @@ public final class Cas20ProxyRetriever implements ProxyRetriever {
         CommonUtils.assertNotNull(targetService, "targetService cannot be null.");
 
         final URL url = constructUrl(proxyGrantingTicketId, targetService);
-        final String response = CommonUtils.getResponseFromServer(url, this.urlConnectionFactory, this.encoding);
+        final String response;
+
+        if (this.urlConnectionFactory != null) {
+            response = CommonUtils.getResponseFromServer(url, this.urlConnectionFactory, this.encoding);
+        } else {
+            response = CommonUtils.getResponseFromServer(url, this.encoding);
+        }
         final String error = XmlUtils.getTextForElement(response, "proxyFailure");
 
         if (CommonUtils.isNotEmpty(error)) {

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
@@ -361,11 +361,16 @@ public final class CommonUtils {
      */
     @Deprecated
     public static String getResponseFromServer(final String constructedUrl, final String encoding) {
-	try {
-        	return getResponseFromServer(new URL(constructedUrl), DEFAULT_URL_CONNECTION_FACTORY, encoding);
-	} catch (final Exception e) {
-		throw new RuntimeException(e);
-	}
+        try {
+            return getResponseFromServer(new URL(constructedUrl), DEFAULT_URL_CONNECTION_FACTORY, encoding);
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Deprecated
+    public static String getResponseFromServer(final URL constructedUrl, final String encoding) {
+        return getResponseFromServer(constructedUrl, DEFAULT_URL_CONNECTION_FACTORY, encoding);
     }
 
     /**


### PR DESCRIPTION
Problem: We removed the two string constructor which breaks Spring Security compatibility.
Solution: Add it back as deprecated so that Spring Security can upgrade.
