### PR TITLE
CASC-229 Make Front Channel SSO Optional so that backwards compatibility...

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutFilter.java
@@ -49,7 +49,7 @@ public final class SingleSignOutFilter extends AbstractConfigurationFilter {
                     SingleSignOutHandler.DEFAULT_FRONT_LOGOUT_PARAMETER_NAME));
             HANDLER.setRelayStateParameterName(getPropertyFromInitParams(filterConfig, "relayStateParameterName",
                     SingleSignOutHandler.DEFAULT_RELAY_STATE_PARAMETER_NAME));
-            HANDLER.setCasServerUrlPrefix(getPropertyFromInitParams(filterConfig, "casServerUrlPrefix", null));
+            HANDLER.setCasServerUrlPrefix(getPropertyFromInitParams(filterConfig, "casServerUrlPrefix", ""));
             HANDLER.setArtifactParameterOverPost(parseBoolean(getPropertyFromInitParams(filterConfig,
                     "artifactParameterOverPost", "false")));
             HANDLER.setEagerlyCreateSessions(parseBoolean(getPropertyFromInitParams(filterConfig,

--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHandler.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHandler.java
@@ -70,7 +70,7 @@ public final class SingleSignOutHandler {
     private String relayStateParameterName = DEFAULT_RELAY_STATE_PARAMETER_NAME;
     
     /** The prefix url of the CAS server */
-    private String casServerUrlPrefix;
+    private String casServerUrlPrefix = "";
 
     private boolean artifactParameterOverPost = false;
 
@@ -141,6 +141,10 @@ public final class SingleSignOutHandler {
             CommonUtils.assertNotNull(this.relayStateParameterName, "relayStateParameterName cannot be null.");
             CommonUtils.assertNotNull(this.casServerUrlPrefix, "casServerUrlPrefix cannot be null.");
 
+            if (CommonUtils.isBlank(this.casServerUrlPrefix)) {
+                logger.warn("Front Channel single sign out redirects are disabled when the 'casServerUrlPrefix' value is not set.");
+            }
+
             if (this.artifactParameterOverPost) {
                 this.safeParameters = Arrays.asList(this.logoutParameterName, this.artifactParameterName);
             } else {
@@ -176,14 +180,15 @@ public final class SingleSignOutHandler {
     }
 
     /**
-     * Determines whether the given request is a CAS front channel logout request.
+     * Determines whether the given request is a CAS front channel logout request.  Front Channel log out requests are only supported
+     * when the 'casServerUrlPrefix' value is set.
      *
      * @param request HTTP request.
      *
      * @return True if request is logout request, false otherwise.
      */
     private boolean isFrontChannelLogoutRequest(final HttpServletRequest request) {
-        return "GET".equals(request.getMethod())
+        return "GET".equals(request.getMethod()) && CommonUtils.isNotBlank(this.casServerUrlPrefix)
                 && CommonUtils.isNotBlank(CommonUtils.safeGetParameter(request, this.frontLogoutParameterName));
     }
 


### PR DESCRIPTION
... is maintained.

Problem: Spring Security adopters will fail to be able to drop in a new version of CAS Client for Java if this feature is enabled by default/required.
Solution: Force a fail-safe optional mode if the value is not provided.
