### PR TITLE
CAS-228 URL Encoding Fix for 3.2.x branch

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/validation/AbstractUrlBasedTicketValidator.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/validation/AbstractUrlBasedTicketValidator.java
@@ -115,7 +115,7 @@ public abstract class AbstractUrlBasedTicketValidator implements TicketValidator
 
         log.debug("Placing URL parameters in map.");
         urlParameters.put("ticket", ticket);
-        urlParameters.put("service", encodeUrl(serviceUrl));
+        urlParameters.put("service", serviceUrl);
 
         if (this.renew) {
             urlParameters.put("renew", "true");
@@ -148,7 +148,8 @@ public abstract class AbstractUrlBasedTicketValidator implements TicketValidator
                 buffer.append(i++ == 0 ? "?" : "&");
                 buffer.append(key);
                 buffer.append("=");
-                buffer.append(value);
+                final String encodedValue = encodeUrl(value);
+                buffer.append(encodedValue);
             }
         }
 

--- a/cas-client-core/src/main/java/org/jasig/cas/client/validation/Cas20ServiceTicketValidator.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/validation/Cas20ServiceTicketValidator.java
@@ -70,8 +70,8 @@ public class Cas20ServiceTicketValidator extends AbstractCasProtocolUrlBasedTick
      *
      * @param urlParameters the Map containing the existing parameters to send to the server.
      */
-    protected final void populateUrlAttributeMap(final Map<String,String> urlParameters) {
-        urlParameters.put("pgtUrl", encodeUrl(this.proxyCallbackUrl));
+    protected final void populateUrlAttributeMap(final Map<String, String> urlParameters) {
+        urlParameters.put("pgtUrl", this.proxyCallbackUrl);
     }
 
     protected String getUrlSuffix() {

--- a/cas-client-core/src/test/java/org/jasig/cas/client/validation/Cas10TicketValidatorTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/validation/Cas10TicketValidatorTests.java
@@ -19,13 +19,10 @@
 
 package org.jasig.cas.client.validation;
 
-
+import java.io.UnsupportedEncodingException;
 import org.jasig.cas.client.PublicTestHttpServer;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.UnsupportedEncodingException;
 
 import static org.junit.Assert.*;
 
@@ -88,5 +85,16 @@ public final class Cas10TicketValidatorTests extends AbstractTicketValidatorTest
         } catch (final TicketValidationException e) {
             // expected
         }
+    }
+
+    @Test
+    public void urlEncodedValues() {
+        final String ticket = "ST-1-owKEOtYJjg77iHcCQpkl-cas01.example.org%26%73%65%72%76%69%63%65%3d%68%74%74%70%25%33%41%25%32%46%25%32%46%31%32%37%2e%30%2e%30%2e%31%25%32%46%62%6f%72%69%6e%67%25%32%46%23";
+        final String service = "foobar";
+        final String url = this.ticketValidator.constructValidationUrl(ticket, service);
+
+        final String encodedValue = this.ticketValidator.encodeUrl(ticket);
+        assertTrue(url.contains(encodedValue));
+        assertFalse(url.contains(ticket));
     }
 }


### PR DESCRIPTION
Problem: We currently don't pass encoded values to the server, possibly resolving in parsing/extraction errors.
Solution: URL Encode all values instead of just the service url.

NOTE: Atlassian modules are preventing clean build.
