### PR TITLE
Introduced common method in order to retrieve Assertion object

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/authentication/AuthenticationFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/authentication/AuthenticationFilter.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 
 import org.jasig.cas.client.Protocol;
 import org.jasig.cas.client.configuration.ConfigurationKeys;
@@ -148,8 +147,7 @@ public class AuthenticationFilter extends AbstractCasFilter {
             return;
         }
         
-        final HttpSession session = request.getSession(false);
-        final Assertion assertion = session != null ? (Assertion) session.getAttribute(CONST_CAS_ASSERTION) : null;
+        final Assertion assertion = CommonUtils.retrieveAssertionFromRequestOrSession(request);
 
         if (assertion != null) {
             filterChain.doFilter(request, response);

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/AssertionThreadLocalFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/AssertionThreadLocalFilter.java
@@ -40,10 +40,7 @@ public final class AssertionThreadLocalFilter implements Filter {
     public void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse,
             final FilterChain filterChain) throws IOException, ServletException {
         final HttpServletRequest request = (HttpServletRequest) servletRequest;
-        final HttpSession session = request.getSession(false);
-        final Assertion assertion = (Assertion) (session == null ? request
-                .getAttribute(AbstractCasFilter.CONST_CAS_ASSERTION) : session
-                .getAttribute(AbstractCasFilter.CONST_CAS_ASSERTION));
+        final Assertion assertion = CommonUtils.retrieveAssertionFromRequestOrSession(request);
 
         try {
             AssertionHolder.setAssertion(assertion);

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
@@ -27,9 +27,12 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorage;
 import org.jasig.cas.client.ssl.HttpURLConnectionFactory;
 import org.jasig.cas.client.ssl.HttpsURLConnectionFactory;
+import org.jasig.cas.client.validation.Assertion;
 import org.jasig.cas.client.validation.ProxyList;
 import org.jasig.cas.client.validation.ProxyListEditor;
 import org.slf4j.Logger;
@@ -465,5 +468,17 @@ public final class CommonUtils {
         } catch (final IOException e) {
             //ignore
         }
+    }
+
+    /**
+     * Retrieves the {@link Assertion} object from request or session.
+     * @param request the HttpServletRequest.  CANNOT be NULL.
+     * @return the {@link Assertion} object if it exists, null otherwise.
+     */
+    public static Assertion retrieveAssertionFromRequestOrSession(final HttpServletRequest request) {
+        final HttpSession session = request.getSession(false);
+        return (Assertion) (session == null ? request
+                .getAttribute(AbstractCasFilter.CONST_CAS_ASSERTION) : session
+                .getAttribute(AbstractCasFilter.CONST_CAS_ASSERTION));
     }
 }

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/HttpServletRequestWrapperFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/HttpServletRequestWrapperFilter.java
@@ -74,10 +74,7 @@ public final class HttpServletRequestWrapperFilter extends AbstractConfiguration
 
     protected AttributePrincipal retrievePrincipalFromSessionOrRequest(final ServletRequest servletRequest) {
         final HttpServletRequest request = (HttpServletRequest) servletRequest;
-        final HttpSession session = request.getSession(false);
-        final Assertion assertion = (Assertion) (session == null ? request
-                .getAttribute(AbstractCasFilter.CONST_CAS_ASSERTION) : session
-                .getAttribute(AbstractCasFilter.CONST_CAS_ASSERTION));
+        final Assertion assertion = CommonUtils.retrieveAssertionFromRequestOrSession(request);
 
         return assertion == null ? null : assertion.getPrincipal();
     }


### PR DESCRIPTION
1. Introduced the new method retrieveAssertionFromRequestOrSession in CommonUtils
2. Changed AssertionThreadLocalFilter, AuthenticationFilter and HttpServletRequestWrapperFilter in order to use the new method
