### PR TITLE
Add support for changeSessionIdOnAuthentication config parameter

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/configuration/ConfigurationKeys.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/configuration/ConfigurationKeys.java
@@ -68,6 +68,7 @@ public interface ConfigurationKeys {
     ConfigurationKey<Boolean> EXCEPTION_ON_VALIDATION_FAILURE = new ConfigurationKey<Boolean>("exceptionOnValidationFailure", Boolean.TRUE);
     ConfigurationKey<Boolean> REDIRECT_AFTER_VALIDATION = new ConfigurationKey<Boolean>("redirectAfterValidation", Boolean.TRUE);
     ConfigurationKey<Boolean> USE_SESSION = new ConfigurationKey<Boolean>("useSession", Boolean.TRUE);
+    ConfigurationKey<Boolean> CHANGE_SESSION_ID_ON_AUTHENTICATION= new ConfigurationKey<Boolean>("changeSessionIdOnAuthentication", Boolean.FALSE);
     ConfigurationKey<String> SECRET_KEY = new ConfigurationKey<String>("secretKey", null);
     ConfigurationKey<String> CIPHER_ALGORITHM = new ConfigurationKey<String>("cipherAlgorithm", "DESede");
     ConfigurationKey<String> PROXY_RECEPTOR_URL = new ConfigurationKey<String>("proxyReceptorUrl", null);


### PR DESCRIPTION
Java CAS client is vulnerable to session fixation. Best way to avoid it is to change session id once session once the user is authenticated, after the ticket validation.

This patch adds a new "changeSessionIdOnAuthentication" parameter to the validator. Default behaviour is to act as usually, but we can force to change session id and regenerate the session to allow for extra security.

```
<filter>
    <filter-name>CAS Validation Filter</filter-name>
    <filter-class>org.jasig.cas.client.validation.Cas20ProxyReceivingTicketValidationFilter</filter-class>
    ...
    <init-param>
        <param-name>changeSessionIdOnAuthentication</param-name>
        <param-value>true</param-value>
    </init-param>
</filter>
```
