### PR TITLE
Return existing user if session is already authenticated

### DIFF
--- a/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/atlassian/Jira44CasAuthenticator.java
+++ b/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/atlassian/Jira44CasAuthenticator.java
@@ -52,6 +52,7 @@ public final class Jira44CasAuthenticator extends JiraSeraphAuthenticator {
         Principal existingUser = getUserFromSession(request);
         if (existingUser != null) {
             LOGGER.debug("Session found; user already logged in.");
+            return existingUser;
         }
 
         final HttpSession session = request.getSession();


### PR DESCRIPTION
Our JIRA instance records multiple logins per call I think because it is processing a new login each time instead of returning if the session is already authenticated.
