### PR TITLE
fix setServerName bug

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/AbstractCasFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/AbstractCasFilter.java
@@ -113,16 +113,20 @@ public abstract class AbstractCasFilter extends AbstractConfigurationFilter {
      * @param serverName the serverName. If this method is called, this should not be null.  This AND service should not be both configured.
      */
     public final void setServerName(final String serverName) {
-        if (serverName != null && serverName.endsWith("/")) {
-            this.serverName = serverName.substring(0, serverName.length() - 1);
-            logger.info("Eliminated extra slash from serverName [{}].  It is now [{}]", serverName, this.serverName);
-        } else {
-            this.serverName = serverName;
+        if (serverName != null) {
+            if (serverName.endsWith("/")) {
+                this.serverName = serverName.substring(0, serverName.length() - 1);
+                logger.info("Eliminated extra slash from serverName [{}].  It is now [{}]", serverName, this.serverName);
+            }
+            else {
+                this.serverName = serverName;
+            }
         }
     }
 
     public final void setService(final String service) {
-        this.service = service;
+        if (service != null)
+            this.service = service;
     }
 
     public final void setEncodeServiceUrl(final boolean encodeServiceUrl) {


### PR DESCRIPTION
With Spring DelegatingFilterProxy,  'serverName' will be override.

```xml
  <filter>
        <filter-name>casAuthenticationFilter</filter-name>
        <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
        <init-param>
            <param-name>targetFilterLifecycle</param-name>
            <param-value>true</param-value>
        </init-param>
        <init-param>
            <param-name>ignorePattern</param-name>
            <param-value>/u/sendsmscode/join</param-value>
        </init-param>
    </filter>
```

```xml
  <bean
        name="casAuthenticationFilter"
        class="org.jasig.cas.client.authentication.AuthenticationFilter"
        p:casServerLoginUrl="${cas.server.loginUrl}"
        p:renew="${cas.server.renew}"
        p:gateway="${cas.server.gateway}"
        p:serverName="${cas.client.serverName}">
    </bean>
```