### PR TITLE
Decouple common CAS protocol support from servlet API

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/http/ClientSession.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/http/ClientSession.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.cas.client.http;
+
+/**
+ * An abstraction of the essential properties of a client session necessary
+ * for CAS protocol handling.
+ *
+ * @author Carl Harris
+ */
+public interface ClientSession {
+
+  /**
+   * Gets the session identifier.
+   * <p>
+   * The scope of uniqueness of this identifier must be such that two distinct
+   * instances of session created using the same classloader have unequal
+   * identifiers.
+   *
+   * @return session identifier
+     */
+  String getId();
+
+  /**
+   * Invalidates this session.
+   * @throws RuntimeException if the session has already been invalidated
+   */
+  void invalidate();
+
+}

--- a/cas-client-core/src/main/java/org/jasig/cas/client/http/HttpRequest.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/http/HttpRequest.java
@@ -1,0 +1,92 @@
+package org.jasig.cas.client.http;
+
+/**
+ * An abstraction of the essential properties of an HTTP request necessary for
+ * CAS protocol handling.
+ *
+ * @author Carl Harris
+ */
+public interface HttpRequest {
+
+    /**
+     * Gets the HTTP method name.
+     * @return method name
+     */
+    String getMethod();
+
+    /**
+     * Gets the URL the client used to make the request.
+     * @return URL
+     */
+    String getRequestURL();
+
+    /**
+     * Gets the part of this request's URL that appears in the first line of the HTTP request, following the method
+     * name and before the query string (if present) and HTTP protocol name.
+     * <p>
+     * In particular, the return value does not include the scheme or authority (server name and port) portion of the
+     * URL.
+     * @return request URI
+     */
+    String getRequestURI();
+
+    /**
+     * Gets the query string specified in first line of the HTTP request.
+     * @return query string or {@code null} if no query string was specified
+     */
+    String getQueryString();
+
+    /**
+     * Gets the value associated with the first appearance of a parameter in the request.
+     * @param name name of the subject parameter
+     * @return parameter value or {@code null} if no parameter exists with the given {@code name}
+     */
+    String getParameter(String name);
+
+    /**
+     * Gets the MIME media type of the body of the request.
+     * @return MIME media type or {@code null} if not known
+     */
+    String getContentType();
+
+    /**
+     * Gets the value associated with the first appearance of a header in the request.
+     * @param name name of the subject header (case insensitive)
+     * @return header value or {@code null} if no header exists with the given {@code name}
+     */
+    String getHeader(String name);
+
+    /**
+     * Gets an existing client session associated with this request.
+     * @return client session or {@code null} if no session exists
+     */
+    ClientSession getSession();
+
+    /**
+     * Gets the client session associated with this request, creating it if necessary.
+     * @return client session
+     */
+    ClientSession getOrCreateSession();
+
+    /**
+     * Tests whether this request was received over a secure transport.
+     * @return {@code true} if request was received over a secure transport
+     */
+    boolean isSecure();
+
+    /**
+     * Gets the server (TCP) port over which this request was received.
+     * @return server port
+     */
+    int getServerPort();
+
+    /**
+     * Notifies the recipient (typically a servlet container) that the user associated
+     * with the client session should be logged out.
+     * <p>
+     * Invoking this method does not necessarily have any effect on an associated client
+     * session.
+     */
+    void logout();
+
+}

--- a/cas-client-core/src/main/java/org/jasig/cas/client/http/HttpResponse.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/http/HttpResponse.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.cas.client.http;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * An abstraction of the essential properties of an HTTP response necessary for
+ * CAS protocol handling.
+ *
+ * @author Carl Harris
+ */
+public interface HttpResponse {
+
+    /**
+     * Gets a writer that can be used to send character text to the connected client.
+     * @return writer
+     * @throws IOException
+     */
+    Writer getWriter() throws IOException;
+
+    /**
+     * Encodes the specified URL by including the session ID, or, if encoding is not needed, returns the URL unchanged.
+     * @param url the subject URL
+     * @return encoded URL
+     */
+    String encodeURL(String url);
+
+    /**
+     * Sends a temporary redirect response to the client using the specified redirect location URL.
+     * <p>
+     * An implementation should return a 302 response with a {@code Location} header containing
+     * the specified URL.
+     *
+     * @param url the URL to include in the {@code Location} header of the response.
+     * @throws IOException
+     */
+    void sendRedirect(String url) throws IOException;
+
+}

--- a/cas-client-core/src/main/java/org/jasig/cas/client/http/package-info.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/http/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * HTTP protocol API
+ * <p>
+ * The interfaces defined in this package allow CAS protocol interactions to be
+ * truly API agnostic, since it none of these interfaces are coupled to the
+ * servlet API.
+ */
+package org.jasig.cas.client.http;

--- a/cas-client-core/src/main/java/org/jasig/cas/client/http/servlet/DelegatingClientSession.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/http/servlet/DelegatingClientSession.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.cas.client.http.servlet;
+
+import org.jasig.cas.client.http.ClientSession;
+
+import javax.servlet.http.HttpSession;
+
+/**
+ * A {@link ClientSession} that delegates to an {@link HttpSession}.
+ *
+ * @author Carl Harris
+ */
+public class DelegatingClientSession implements ClientSession {
+
+    private final HttpSession delegate;
+
+    public DelegatingClientSession(final HttpSession delegate) {
+        if (delegate == null) {
+            throw new IllegalArgumentException("delegate is required");
+        }
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getId() {
+        return delegate.getId();
+    }
+
+    @Override
+    public void invalidate() {
+        delegate.invalidate();
+    }
+
+}

--- a/cas-client-core/src/main/java/org/jasig/cas/client/http/servlet/DelegatingHttpRequest.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/http/servlet/DelegatingHttpRequest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.cas.client.http.servlet;
+
+import org.jasig.cas.client.http.ClientSession;
+import org.jasig.cas.client.http.HttpRequest;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+/**
+ * An {@link HttpRequest} that delegates to a {@link HttpServletRequest}.
+ *
+ * @author Carl Harris
+ */
+public class DelegatingHttpRequest implements HttpRequest {
+
+    private final LogoutStrategy logoutStrategy = isServlet30() ?
+            Servlet30LogoutStrategy.INSTANCE : Servlet25LogoutStrategy.INSTANCE;
+
+    private final HttpServletRequest delegate;
+
+    public DelegatingHttpRequest(final HttpServletRequest delegate) {
+        if (delegate == null) {
+            throw new IllegalArgumentException("delegate is required");
+        }
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getMethod() {
+        return delegate.getMethod();
+    }
+
+    @Override
+    public String getRequestURL() {
+        return delegate.getRequestURL().toString();
+    }
+
+    @Override
+    public String getRequestURI() {
+        return delegate.getRequestURI();
+    }
+
+    @Override
+    public String getQueryString() {
+        return delegate.getQueryString();
+    }
+
+    @Override
+    public String getContentType() {
+        return delegate.getContentType();
+    }
+
+    @Override
+    public String getParameter(final String name) {
+        return delegate.getParameter(name);
+    }
+
+    @Override
+    public String getHeader(final String name) {
+        return delegate.getHeader(name);
+    }
+
+    @Override
+    public ClientSession getSession() {
+        final HttpSession sessionDelegate = delegate.getSession(false);
+        if (sessionDelegate == null) return null;
+        return new DelegatingClientSession(sessionDelegate);
+    }
+
+    @Override
+    public ClientSession getOrCreateSession() {
+        final HttpSession sessionDelegate = delegate.getSession(true);
+        return new DelegatingClientSession(sessionDelegate);
+    }
+
+
+    @Override
+    public boolean isSecure() {
+        return delegate.isSecure();
+    }
+
+    @Override
+    public int getServerPort() {
+        return delegate.getServerPort();
+    }
+
+    @Override
+    public void logout() {
+        logoutStrategy.logout(delegate);
+    }
+
+    private static boolean isServlet30() {
+        try {
+            return HttpServletRequest.class.getMethod("logout") != null;
+        } catch (final NoSuchMethodException e) {
+            return false;
+        }
+    }
+
+    /**
+     * A strategy for performing logout for an HTTP servlet request.
+     */
+    private interface LogoutStrategy {
+
+        void logout(HttpServletRequest request);
+
+    }
+
+    private static class Servlet25LogoutStrategy implements LogoutStrategy {
+
+        static final LogoutStrategy INSTANCE = new Servlet25LogoutStrategy();
+
+        private Servlet25LogoutStrategy() {}
+
+        @Override
+        public void logout(final HttpServletRequest request) {
+            // nothing additional to do here
+        }
+
+    }
+
+    private static class Servlet30LogoutStrategy implements LogoutStrategy {
+
+        static final LogoutStrategy INSTANCE = new Servlet30LogoutStrategy();
+
+        private Servlet30LogoutStrategy() {}
+
+        @Override
+        public void logout(final HttpServletRequest request) {
+            try {
+                request.logout();
+            } catch (ServletException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+}

--- a/cas-client-core/src/main/java/org/jasig/cas/client/http/servlet/DelegatingHttpResponse.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/http/servlet/DelegatingHttpResponse.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.cas.client.http.servlet;
+
+import org.jasig.cas.client.http.HttpResponse;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * An {@link HttpResponse} that delegates to an {@link HttpServletResponse}.
+ *
+ * @author Carl Harris
+ */
+public class DelegatingHttpResponse implements HttpResponse {
+
+    private final HttpServletResponse delegate;
+
+    public DelegatingHttpResponse(final HttpServletResponse delegate) {
+        if (delegate == null) {
+            throw new IllegalArgumentException("delegate is required");
+        }
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Writer getWriter() throws IOException {
+        return delegate.getWriter();
+    }
+
+    @Override
+    public String encodeURL(final String url) {
+        return delegate.encodeURL(url);
+    }
+
+    @Override
+    public void sendRedirect(final String url) throws IOException {
+        delegate.sendRedirect(url);
+    }
+
+}

--- a/cas-client-core/src/main/java/org/jasig/cas/client/http/servlet/package-info.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/http/servlet/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * HTTP API implementation over Servlet API
+ */
+package org.jasig.cas.client.http.servlet;

--- a/cas-client-core/src/main/java/org/jasig/cas/client/jaas/Servlet3AuthenticationFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/jaas/Servlet3AuthenticationFilter.java
@@ -30,6 +30,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.jasig.cas.client.Protocol;
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
 import org.jasig.cas.client.util.AbstractCasFilter;
 import org.jasig.cas.client.util.CommonUtils;
 
@@ -60,7 +61,8 @@ public final class Servlet3AuthenticationFilter extends AbstractCasFilter {
         final HttpServletRequest request = (HttpServletRequest) servletRequest;
         final HttpServletResponse response = (HttpServletResponse) servletResponse;
         final HttpSession session = request.getSession();
-        final String ticket = CommonUtils.safeGetParameter(request, getProtocol().getArtifactParameterName());
+        final String ticket = CommonUtils.safeGetParameter(new DelegatingHttpRequest(request),
+                getProtocol().getArtifactParameterName());
 
         if (session != null && session.getAttribute(CONST_CAS_ASSERTION) == null && ticket != null) {
             try {

--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/HashMapBackedSessionMappingStorage.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/HashMapBackedSessionMappingStorage.java
@@ -21,6 +21,8 @@ package org.jasig.cas.client.session;
 import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpSession;
+
+import org.jasig.cas.client.http.ClientSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +39,7 @@ public final class HashMapBackedSessionMappingStorage implements SessionMappingS
     /**
      * Maps the ID from the CAS server to the Session.
      */
-    private final Map<String, HttpSession> MANAGED_SESSIONS = new HashMap<String, HttpSession>();
+    private final Map<String, ClientSession> MANAGED_SESSIONS = new HashMap<String, ClientSession>();
 
     /**
      * Maps the Session ID to the key from the CAS Server.
@@ -46,7 +48,7 @@ public final class HashMapBackedSessionMappingStorage implements SessionMappingS
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    public synchronized void addSessionById(String mappingId, HttpSession session) {
+    public synchronized void addSessionById(String mappingId, ClientSession session) {
         ID_TO_SESSION_KEY_MAPPING.put(session.getId(), mappingId);
         MANAGED_SESSIONS.put(mappingId, session);
 
@@ -68,8 +70,8 @@ public final class HashMapBackedSessionMappingStorage implements SessionMappingS
         ID_TO_SESSION_KEY_MAPPING.remove(sessionId);
     }
 
-    public synchronized HttpSession removeSessionByMappingId(String mappingId) {
-        final HttpSession session = MANAGED_SESSIONS.get(mappingId);
+    public synchronized ClientSession removeSessionByMappingId(String mappingId) {
+        final ClientSession session = MANAGED_SESSIONS.get(mappingId);
 
         if (session != null) {
             removeBySessionById(session.getId());

--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/SessionMappingStorage.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/SessionMappingStorage.java
@@ -20,6 +20,8 @@ package org.jasig.cas.client.session;
 
 import javax.servlet.http.HttpSession;
 
+import org.jasig.cas.client.http.ClientSession;
+
 /**
  * Stores the mapping between sessions and keys to be retrieved later.
  * 
@@ -34,9 +36,9 @@ public interface SessionMappingStorage {
      * Remove the HttpSession based on the mappingId.
      * 
      * @param mappingId the id the session is keyed under.
-     * @return the HttpSession if it exists.
+     * @return the client session if it exists.
      */
-    HttpSession removeSessionByMappingId(String mappingId);
+    ClientSession removeSessionByMappingId(String mappingId);
 
     /**
      * Remove a session by its Id.
@@ -47,8 +49,8 @@ public interface SessionMappingStorage {
     /**
      * Add a session by its mapping Id.
      * @param mappingId the id to map the session to.
-     * @param session the HttpSession.
+     * @param session the client session.
      */
-    void addSessionById(String mappingId, HttpSession session);
+    void addSessionById(String mappingId, ClientSession session);
 
 }

--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutFilter.java
@@ -26,6 +26,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.jasig.cas.client.configuration.ConfigurationKeys;
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
+import org.jasig.cas.client.http.servlet.DelegatingHttpResponse;
 import org.jasig.cas.client.util.AbstractConfigurationFilter;
 
 /**
@@ -93,7 +95,7 @@ public final class SingleSignOutFilter extends AbstractConfigurationFilter {
             HANDLER.init();
         }
 
-        if (HANDLER.process(request, response)) {
+        if (HANDLER.process(new DelegatingHttpRequest(request), new DelegatingHttpResponse(response))) {
             filterChain.doFilter(servletRequest, servletResponse);
         }
     }

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/AbstractCasFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/AbstractCasFilter.java
@@ -20,6 +20,8 @@ package org.jasig.cas.client.util;
 
 import org.jasig.cas.client.Protocol;
 import org.jasig.cas.client.configuration.ConfigurationKeys;
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
+import org.jasig.cas.client.http.servlet.DelegatingHttpResponse;
 
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
@@ -101,7 +103,8 @@ public abstract class AbstractCasFilter extends AbstractConfigurationFilter {
     }
 
     protected final String constructServiceUrl(final HttpServletRequest request, final HttpServletResponse response) {
-        return CommonUtils.constructServiceUrl(request, response, this.service, this.serverName,
+        return CommonUtils.constructServiceUrl(new DelegatingHttpRequest(request),
+                new DelegatingHttpResponse(response), this.service, this.serverName,
                 this.protocol.getServiceParameterName(),
                 this.protocol.getArtifactParameterName(), this.encodeServiceUrl);
     }
@@ -140,6 +143,7 @@ public abstract class AbstractCasFilter extends AbstractConfigurationFilter {
      * @return the ticket if its found, null otherwise.
      */
     protected String retrieveTicketFromRequest(final HttpServletRequest request) {
-        return CommonUtils.safeGetParameter(request, this.protocol.getArtifactParameterName());
+        return CommonUtils.safeGetParameter(new DelegatingHttpRequest(request),
+                this.protocol.getArtifactParameterName());
     }
 }

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
@@ -18,16 +18,22 @@
  */
 package org.jasig.cas.client.util;
 
-import java.io.*;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
-import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.*;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.jasig.cas.client.Protocol;
+import org.jasig.cas.client.http.HttpRequest;
+import org.jasig.cas.client.http.HttpResponse;
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorage;
 import org.jasig.cas.client.ssl.HttpURLConnectionFactory;
 import org.jasig.cas.client.ssl.HttpsURLConnectionFactory;
@@ -201,8 +207,8 @@ public final class CommonUtils {
         }
     }
 
-    public static void readAndRespondToProxyReceptorRequest(final HttpServletRequest request,
-            final HttpServletResponse response, final ProxyGrantingTicketStorage proxyGrantingTicketStorage)
+    public static void readAndRespondToProxyReceptorRequest(final HttpRequest request,
+            final HttpResponse response, final ProxyGrantingTicketStorage proxyGrantingTicketStorage)
             throws IOException {
         final String proxyGrantingTicketIou = request.getParameter(PARAM_PROXY_GRANTING_TICKET_IOU);
 
@@ -225,7 +231,7 @@ public final class CommonUtils {
         response.getWriter().write("<casClient:proxySuccess xmlns:casClient=\"http://www.yale.edu/tp/casClient\" />");
     }
 
-    protected static String findMatchingServerName(final HttpServletRequest request, final String serverName) {
+    protected static String findMatchingServerName(final HttpRequest request, final String serverName) {
         final String[] serverNames = serverName.split(" ");
 
         if (serverNames == null || serverNames.length == 0 || serverNames.length == 1) {
@@ -267,7 +273,7 @@ public final class CommonUtils {
         return schemeIndex != portIndex;
     }
 
-    private static boolean requestIsOnStandardPort(final HttpServletRequest request) {
+    private static boolean requestIsOnStandardPort(final HttpRequest request) {
         final int serverPort = request.getServerPort();
         return serverPort == 80 || serverPort == 443;
     }
@@ -289,7 +295,7 @@ public final class CommonUtils {
      * @return the service url to use.
      */
     @Deprecated
-    public static String constructServiceUrl(final HttpServletRequest request, final HttpServletResponse response,
+    public static String constructServiceUrl(final HttpRequest request, final HttpResponse response,
                                              final String service, final String serverNames,
                                              final String artifactParameterName, final boolean encode) {
         return constructServiceUrl(request, response, service, serverNames, SERVICE_PARAMETER_NAMES
@@ -312,7 +318,7 @@ public final class CommonUtils {
      * @param encode whether to encode the url or not (i.e. Jsession).
      * @return the service url to use.
      */
-    public static String constructServiceUrl(final HttpServletRequest request, final HttpServletResponse response,
+    public static String constructServiceUrl(final HttpRequest request, final HttpResponse response,
             final String service, final String serverNames, final String serviceParameterName,
             final String artifactParameterName, final boolean encode) {
         if (CommonUtils.isNotBlank(service)) {
@@ -373,7 +379,7 @@ public final class CommonUtils {
      * @param parameter the parameter to look for.
      * @return the value of the parameter.
      */
-    public static String safeGetParameter(final HttpServletRequest request, final String parameter,
+    public static String safeGetParameter(final HttpRequest request, final String parameter,
             final List<String> parameters) {
         if ("POST".equals(request.getMethod()) && parameters.contains(parameter)) {
             LOGGER.debug("safeGetParameter called on a POST HttpServletRequest for Restricted Parameters.  Cannot complete check safely.  Reverting to standard behavior for this Parameter");
@@ -383,7 +389,7 @@ public final class CommonUtils {
                 .getParameter(parameter);
     }
 
-    public static String safeGetParameter(final HttpServletRequest request, final String parameter) {
+    public static String safeGetParameter(final HttpRequest request, final String parameter) {
         return safeGetParameter(request, parameter, Arrays.asList("logoutRequest"));
     }
 
@@ -465,7 +471,7 @@ public final class CommonUtils {
      * @param response the HttpServletResponse.  CANNOT be NULL.
      * @param url the url to redirect to.
      */
-    public static void sendRedirect(final HttpServletResponse response, final String url) {
+    public static void sendRedirect(final HttpResponse response, final String url) {
         try {
             response.sendRedirect(url);
         } catch (final Exception e) {

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/DelegatingFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/DelegatingFilter.java
@@ -18,12 +18,14 @@
  */
 package org.jasig.cas.client.util;
 
-import java.io.IOException;
-import java.util.Map;
-import javax.servlet.*;
-import javax.servlet.http.HttpServletRequest;
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.Map;
 
 /**
  * A Delegating Filter looks up a parameter in the request object and matches
@@ -85,7 +87,8 @@ public final class DelegatingFilter implements Filter {
     public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain filterChain)
             throws IOException, ServletException {
 
-        final String parameter = CommonUtils.safeGetParameter((HttpServletRequest) request, this.requestParameterName);
+        final String parameter = CommonUtils.safeGetParameter(new DelegatingHttpRequest((HttpServletRequest) request),
+                this.requestParameterName);
 
         if (CommonUtils.isNotEmpty(parameter)) {
             for (final String key : this.delegators.keySet()) {

--- a/cas-client-core/src/main/java/org/jasig/cas/client/validation/Cas20ProxyReceivingTicketValidationFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/validation/Cas20ProxyReceivingTicketValidationFilter.java
@@ -18,19 +18,21 @@
  */
 package org.jasig.cas.client.validation;
 
-import java.io.IOException;
-import java.util.*;
-import javax.servlet.*;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.jasig.cas.client.Protocol;
 import org.jasig.cas.client.configuration.ConfigurationKeys;
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
+import org.jasig.cas.client.http.servlet.DelegatingHttpResponse;
 import org.jasig.cas.client.proxy.*;
 import org.jasig.cas.client.ssl.HttpURLConnectionFactory;
 import org.jasig.cas.client.ssl.HttpsURLConnectionFactory;
 import org.jasig.cas.client.util.CommonUtils;
 import org.jasig.cas.client.util.ReflectUtils;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.*;
 
 import static org.jasig.cas.client.configuration.ConfigurationKeys.*;
 
@@ -207,7 +209,10 @@ public class Cas20ProxyReceivingTicketValidationFilter extends AbstractTicketVal
         }
 
         try {
-            CommonUtils.readAndRespondToProxyReceptorRequest(request, response, this.proxyGrantingTicketStorage);
+            CommonUtils.readAndRespondToProxyReceptorRequest(
+                    new DelegatingHttpRequest(request),
+                    new DelegatingHttpResponse(response),
+                    this.proxyGrantingTicketStorage);
         } catch (final RuntimeException e) {
             logger.error(e.getMessage(), e);
             throw e;

--- a/cas-client-core/src/test/java/org/jasig/cas/client/http/servlet/DelegatingClientSessionTest.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/http/servlet/DelegatingClientSessionTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.cas.client.http.servlet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpSession;
+
+/**
+ * Unit tests for {@link DelegatingClientSession}.
+ *
+ * @author Carl Harris
+ */
+public class DelegatingClientSessionTest {
+
+    private MockHttpSession delegate = new MockHttpSession();
+
+    private DelegatingClientSession session = new DelegatingClientSession(delegate);
+
+    @Test(expected = RuntimeException.class)
+    public void testDelegateRequired() throws Exception {
+        new DelegatingClientSession(null);
+    }
+
+    @Test
+    public void testGetId() throws Exception {
+        assertEquals(session.getId(), delegate.getId());
+    }
+
+    @Test
+    public void testInvalidate() throws Exception {
+        session.invalidate();
+        assertTrue(delegate.isInvalid());
+    }
+
+}

--- a/cas-client-core/src/test/java/org/jasig/cas/client/http/servlet/DelegatingHttpRequestTest.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/http/servlet/DelegatingHttpRequestTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.cas.client.http.servlet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.jasig.cas.client.http.ClientSession;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+
+
+/**
+ * Unit tests for {@link DelegatingHttpRequest}.
+ *
+ * @author Carl Harris
+ */
+public class DelegatingHttpRequestTest {
+
+    private static final String MOCK_PARAMETER = "someParameter";
+    private static final String MOCK_HEADER = "X-Some-Header";
+    private static final String MOCK_VALUE = "some value";
+    private static final String MOCK_QUERY_STRING = "query";
+    private static final int MOCK_PORT = -1;
+    private static final String MOCK_USER = "some user";
+
+
+    private MockHttpServletRequest delegate = new MockHttpServletRequest();
+
+    private DelegatingHttpRequest request = new DelegatingHttpRequest(delegate);
+
+    @Test(expected = RuntimeException.class)
+    public void testDelegateRequired() throws Exception {
+        new DelegatingHttpRequest(null);
+    }
+
+    @Test
+    public void testGetMethod() throws Exception {
+        assertNotNull(delegate.getMethod());
+        assertEquals(delegate.getMethod(), request.getMethod());
+    }
+
+    @Test
+    public void testGetRequestURL() throws Exception {
+        delegate.setScheme("http");
+        delegate.setServerName("localhost");
+        delegate.setServerPort(80);
+        delegate.setRequestURI("/path");
+        assertEquals("http://localhost:80/path", request.getRequestURL());
+    }
+
+    @Test
+    public void testGetRequestURI() throws Exception {
+        delegate.setRequestURI("/path");
+        assertEquals("/path", request.getRequestURI());
+    }
+
+    @Test
+    public void testGetParameter() throws Exception {
+        delegate.addParameter(MOCK_PARAMETER, MOCK_VALUE);
+        assertEquals(MOCK_VALUE, request.getParameter(MOCK_PARAMETER));
+    }
+
+    @Test
+    public void testGetContentType() throws Exception {
+        delegate.setContentType(MOCK_VALUE);
+        assertEquals(MOCK_VALUE, request.getContentType());
+    }
+
+    @Test
+    public void testGetHeader() throws Exception {
+        delegate.addHeader(MOCK_HEADER, MOCK_VALUE);
+        assertEquals(MOCK_VALUE, request.getHeader(MOCK_HEADER));
+    }
+
+    @Test
+    public void testGetQueryString() throws Exception {
+        delegate.setQueryString(MOCK_QUERY_STRING);
+        assertEquals(MOCK_QUERY_STRING, request.getQueryString());
+    }
+
+    @Test
+    public void testGetSession() throws Exception {
+        assertNull(delegate.getSession(false));
+        assertNull(request.getSession());
+        final MockHttpSession session = new MockHttpSession();
+        delegate.setSession(session);
+        final ClientSession clientSession = request.getSession();
+        assertNotNull(clientSession);
+        assertEquals(session.getId(), clientSession.getId());
+    }
+
+    @Test
+    public void testGetOrCreateSession() throws Exception {
+        final ClientSession clientSession = request.getOrCreateSession();
+        assertNotNull(clientSession);
+        assertEquals(delegate.getSession().getId(), clientSession.getId());
+    }
+
+    @Test
+    public void testIsSecure() throws Exception {
+        delegate.setSecure(true);
+        assertTrue(request.isSecure());
+    }
+
+    @Test
+    public void testGetServerPort() throws Exception {
+        delegate.setServerPort(MOCK_PORT);
+        assertEquals(MOCK_PORT, request.getServerPort());
+    }
+
+    @Test
+    public void testLogout() throws Exception {
+        // per servlet 3.0 spec, after HttpServletRequest.logout, the remote user should be null
+        delegate.setRemoteUser(MOCK_USER);
+        request.logout();
+        assertNull(delegate.getRemoteUser());
+    }
+
+}

--- a/cas-client-core/src/test/java/org/jasig/cas/client/http/servlet/DelegatingHttpResponseTest.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/http/servlet/DelegatingHttpResponseTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.cas.client.http.servlet;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * Unit tests for {@link DelegatingHttpResponse}
+ *
+ * @author Carl Harris
+ */
+public class DelegatingHttpResponseTest {
+
+    private static final String MOCK_BODY = "some body";
+    private static final String MOCK_URL = "http://localhost/";
+
+    private MockHttpServletResponse delegate = new MockHttpServletResponse();
+    private DelegatingHttpResponse response = new DelegatingHttpResponse(delegate);
+
+    @Test(expected = RuntimeException.class)
+    public void testDelegateRequired() throws Exception {
+        new DelegatingHttpResponse(null);
+    }
+
+    @Test
+    public void testGetWriter() throws Exception {
+        response.getWriter().write(MOCK_BODY);
+        assertEquals(MOCK_BODY, delegate.getContentAsString());
+    }
+
+    @Test
+    public void testSendRedirect() throws Exception {
+        response.sendRedirect(MOCK_URL);
+        assertEquals(MOCK_URL, delegate.getRedirectedUrl());
+    }
+
+}

--- a/cas-client-core/src/test/java/org/jasig/cas/client/session/SingleSignOutFilterTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/session/SingleSignOutFilterTests.java
@@ -27,6 +27,7 @@ import javax.servlet.ServletException;
 
 import org.jasig.cas.client.Protocol;
 import org.jasig.cas.client.configuration.ConfigurationKeys;
+import org.jasig.cas.client.http.servlet.DelegatingClientSession;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockFilterChain;
@@ -70,7 +71,8 @@ public class SingleSignOutFilterTests {
         final MockHttpSession session = new MockHttpSession();
         request.setSession(session);
         filter.doFilter(request, response, filterChain);
-        assertEquals(session, SingleSignOutFilter.getSingleSignOutHandler().getSessionMappingStorage().removeSessionByMappingId(TICKET));
+        assertEquals(session.getId(),
+            SingleSignOutFilter.getSingleSignOutHandler().getSessionMappingStorage().removeSessionByMappingId(TICKET).getId());
     }
 
     @Test
@@ -79,7 +81,8 @@ public class SingleSignOutFilterTests {
                 LogoutMessageGenerator.generateBackChannelLogoutMessage(TICKET));
         request.setMethod("POST");
         final MockHttpSession session = new MockHttpSession();
-        SingleSignOutFilter.getSingleSignOutHandler().getSessionMappingStorage().addSessionById(TICKET, session);
+        SingleSignOutFilter.getSingleSignOutHandler().getSessionMappingStorage().addSessionById(TICKET,
+                new DelegatingClientSession(session));
         filter.doFilter(request, response, filterChain);
         assertNull(SingleSignOutFilter.getSingleSignOutHandler().getSessionMappingStorage().removeSessionByMappingId(TICKET));
     }
@@ -91,7 +94,8 @@ public class SingleSignOutFilterTests {
         request.setQueryString(ConfigurationKeys.FRONT_LOGOUT_PARAMETER_NAME.getDefaultValue() + "=" + logoutMessage);
         request.setMethod("GET");
         final MockHttpSession session = new MockHttpSession();
-        SingleSignOutFilter.getSingleSignOutHandler().getSessionMappingStorage().addSessionById(TICKET, session);
+        SingleSignOutFilter.getSingleSignOutHandler().getSessionMappingStorage().addSessionById(TICKET,
+                new DelegatingClientSession(session));
         filter.doFilter(request, response, filterChain);
         assertNull(SingleSignOutFilter.getSingleSignOutHandler().getSessionMappingStorage().removeSessionByMappingId(TICKET));
         assertNull(response.getRedirectedUrl());
@@ -106,7 +110,8 @@ public class SingleSignOutFilterTests {
                 ConfigurationKeys.RELAY_STATE_PARAMETER_NAME.getDefaultValue() + "=" + RELAY_STATE);
         request.setMethod("GET");
         final MockHttpSession session = new MockHttpSession();
-        SingleSignOutFilter.getSingleSignOutHandler().getSessionMappingStorage().addSessionById(TICKET, session);
+        SingleSignOutFilter.getSingleSignOutHandler().getSessionMappingStorage().addSessionById(TICKET,
+                new DelegatingClientSession(session));
         filter.doFilter(request, response, filterChain);
         assertNull(SingleSignOutFilter.getSingleSignOutHandler().getSessionMappingStorage().removeSessionByMappingId(TICKET));
         assertEquals(CAS_SERVER_URL_PREFIX + "/logout?_eventId=next&" +

--- a/cas-client-core/src/test/java/org/jasig/cas/client/session/SingleSignOutHandlerTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/session/SingleSignOutHandlerTests.java
@@ -23,6 +23,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import org.jasig.cas.client.http.servlet.DelegatingClientSession;
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
+import org.jasig.cas.client.http.servlet.DelegatingHttpResponse;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -67,7 +70,7 @@ public final class SingleSignOutHandlerTests {
         request.setSession(null);
         request.setParameter(ARTIFACT_PARAMETER_NAME, TICKET);
         request.setQueryString(ARTIFACT_PARAMETER_NAME + "=" + TICKET);
-        assertTrue(handler.process(request, response));
+        assertTrue(handler.process(new DelegatingHttpRequest(request), new DelegatingHttpResponse(response)));
         final SessionMappingStorage storage = handler.getSessionMappingStorage();
         assertNull(storage.removeSessionByMappingId(TICKET));
     }
@@ -78,7 +81,7 @@ public final class SingleSignOutHandlerTests {
         request.setSession(session);
         request.setParameter(ANOTHER_PARAMETER, TICKET);
         request.setQueryString(ANOTHER_PARAMETER + "=" + TICKET);
-        assertTrue(handler.process(request, response));
+        assertTrue(handler.process(new DelegatingHttpRequest(request), new DelegatingHttpResponse(response)));
         final SessionMappingStorage storage = handler.getSessionMappingStorage();
         assertNull(storage.removeSessionByMappingId(TICKET));
     }
@@ -89,9 +92,9 @@ public final class SingleSignOutHandlerTests {
         request.setSession(session);
         request.setParameter(ARTIFACT_PARAMETER_NAME, TICKET);
         request.setQueryString(ARTIFACT_PARAMETER_NAME + "=" + TICKET);
-        assertTrue(handler.process(request, response));
+        assertTrue(handler.process(new DelegatingHttpRequest(request), new DelegatingHttpResponse(response)));
         final SessionMappingStorage storage = handler.getSessionMappingStorage();
-        assertEquals(session, storage.removeSessionByMappingId(TICKET));
+        assertEquals(session.getId(), storage.removeSessionByMappingId(TICKET).getId());
     }
 
     @Test
@@ -101,8 +104,8 @@ public final class SingleSignOutHandlerTests {
         request.setMethod("POST");
         request.setContentType("multipart/form-data");
         final MockHttpSession session = new MockHttpSession();
-        handler.getSessionMappingStorage().addSessionById(TICKET, session);
-        assertTrue(handler.process(request, response));
+        handler.getSessionMappingStorage().addSessionById(TICKET, new DelegatingClientSession(session));
+        assertTrue(handler.process(new DelegatingHttpRequest(request), new DelegatingHttpResponse(response)));
         assertFalse(session.isInvalid());
     }
 
@@ -112,8 +115,8 @@ public final class SingleSignOutHandlerTests {
         request.setParameter(LOGOUT_PARAMETER_NAME, logoutMessage);
         request.setMethod("POST");
         final MockHttpSession session = new MockHttpSession();
-        handler.getSessionMappingStorage().addSessionById(TICKET, session);
-        assertFalse(handler.process(request, response));
+        handler.getSessionMappingStorage().addSessionById(TICKET, new DelegatingClientSession(session));
+        assertFalse(handler.process(new DelegatingHttpRequest(request), new DelegatingHttpResponse(response)));
         assertFalse(session.isInvalid());
     }
 
@@ -123,8 +126,8 @@ public final class SingleSignOutHandlerTests {
         request.setParameter(LOGOUT_PARAMETER_NAME, logoutMessage);
         request.setMethod("POST");
         final MockHttpSession session = new MockHttpSession();
-        handler.getSessionMappingStorage().addSessionById(TICKET, session);
-        assertFalse(handler.process(request, response));
+        handler.getSessionMappingStorage().addSessionById(TICKET, new DelegatingClientSession(session));
+        assertFalse(handler.process(new DelegatingHttpRequest(request), new DelegatingHttpResponse(response)));
         assertTrue(session.isInvalid());
     }
 
@@ -135,8 +138,8 @@ public final class SingleSignOutHandlerTests {
         request.setMethod("GET");
         request.setQueryString(ANOTHER_PARAMETER + "=" + logoutMessage);
         final MockHttpSession session = new MockHttpSession();
-        handler.getSessionMappingStorage().addSessionById(TICKET, session);
-        assertTrue(handler.process(request, response));
+        handler.getSessionMappingStorage().addSessionById(TICKET, new DelegatingClientSession(session));
+        assertTrue(handler.process(new DelegatingHttpRequest(request), new DelegatingHttpResponse(response)));
         assertFalse(session.isInvalid());
     }
 
@@ -147,8 +150,8 @@ public final class SingleSignOutHandlerTests {
         request.setQueryString(FRONT_LOGOUT_PARAMETER_NAME + "=" + logoutMessage);
         request.setMethod("GET");
         final MockHttpSession session = new MockHttpSession();
-        handler.getSessionMappingStorage().addSessionById(TICKET, session);
-        assertFalse(handler.process(request, response));
+        handler.getSessionMappingStorage().addSessionById(TICKET, new DelegatingClientSession(session));
+        assertFalse(handler.process(new DelegatingHttpRequest(request), new DelegatingHttpResponse(response)));
         assertFalse(session.isInvalid());
     }
 
@@ -159,8 +162,8 @@ public final class SingleSignOutHandlerTests {
         request.setQueryString(FRONT_LOGOUT_PARAMETER_NAME + "=" + logoutMessage);
         request.setMethod("GET");
         final MockHttpSession session = new MockHttpSession();
-        handler.getSessionMappingStorage().addSessionById(TICKET, session);
-        assertFalse(handler.process(request, response));
+        handler.getSessionMappingStorage().addSessionById(TICKET, new DelegatingClientSession(session));
+        assertFalse(handler.process(new DelegatingHttpRequest(request), new DelegatingHttpResponse(response)));
         assertTrue(session.isInvalid());
         assertNull(response.getRedirectedUrl());
     }
@@ -173,8 +176,8 @@ public final class SingleSignOutHandlerTests {
         request.setQueryString(FRONT_LOGOUT_PARAMETER_NAME + "=" + logoutMessage + "&" + RELAY_STATE_PARAMETER_NAME + "=" + TICKET);
         request.setMethod("GET");
         final MockHttpSession session = new MockHttpSession();
-        handler.getSessionMappingStorage().addSessionById(TICKET, session);
-        assertFalse(handler.process(request, response));
+        handler.getSessionMappingStorage().addSessionById(TICKET, new DelegatingClientSession(session));
+        assertFalse(handler.process(new DelegatingHttpRequest(request), new DelegatingHttpResponse(response)));
         assertTrue(session.isInvalid());
         assertEquals(URL + "/logout?_eventId=next&" + RELAY_STATE_PARAMETER_NAME + "=" + TICKET,
                 response.getRedirectedUrl());

--- a/cas-client-core/src/test/java/org/jasig/cas/client/util/CommonUtilsTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/util/CommonUtilsTests.java
@@ -25,6 +25,8 @@ import java.util.Collection;
 import junit.framework.TestCase;
 import org.jasig.cas.client.Protocol;
 import org.jasig.cas.client.PublicTestHttpServer;
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
+import org.jasig.cas.client.http.servlet.DelegatingHttpResponse;
 import org.jasig.cas.client.ssl.HttpsURLConnectionFactory;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -132,8 +134,8 @@ public final class CommonUtilsTests extends TestCase {
         request.setScheme("https");
         request.setSecure(true);
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
-                "service", "ticket", false);
+        final String constructedUrl = CommonUtils.constructServiceUrl(new DelegatingHttpRequest(request),
+                new DelegatingHttpResponse(response), null, "www.myserver.com", "service", "ticket", false);
 
         assertEquals(CONST_MY_URL, constructedUrl);
     }
@@ -146,7 +148,8 @@ public final class CommonUtilsTests extends TestCase {
         request.setQueryString("service=this&ticket=that&custom=custom");
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
+        final String constructedUrl = CommonUtils.constructServiceUrl(new DelegatingHttpRequest(request),
+                new DelegatingHttpResponse(response), null, "www.myserver.com",
                 Protocol.CAS3.getServiceParameterName(), Protocol.CAS3.getArtifactParameterName() , false);
 
         assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
@@ -160,7 +163,8 @@ public final class CommonUtilsTests extends TestCase {
         request.setQueryString("service=this&ticket=that&custom=custom");
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "https://www.myserver.com",
+        final String constructedUrl = CommonUtils.constructServiceUrl(new DelegatingHttpRequest(request),
+                new DelegatingHttpResponse(response), null, "https://www.myserver.com",
                 Protocol.CAS3.getServiceParameterName(), Protocol.CAS3.getArtifactParameterName() , false);
 
         assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
@@ -175,7 +179,8 @@ public final class CommonUtilsTests extends TestCase {
         request.setQueryString("TARGET=this&SAMLart=that&custom=custom");
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
+        final String constructedUrl = CommonUtils.constructServiceUrl(new DelegatingHttpRequest(request),
+                new DelegatingHttpResponse(response), null, "www.myserver.com",
                 Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName() , false);
 
         assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
@@ -189,7 +194,8 @@ public final class CommonUtilsTests extends TestCase {
         request.setQueryString("TARGET%3Dthis%26SAMLart%3Dthat%26custom%3Dcustom");
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
+        final String constructedUrl = CommonUtils.constructServiceUrl(new DelegatingHttpRequest(request),
+                new DelegatingHttpResponse(response), null, "www.myserver.com",
                 Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName() , false);
 
         assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
@@ -203,7 +209,8 @@ public final class CommonUtilsTests extends TestCase {
         request.setQueryString("TARGET=Test1&service=Test2&custom=custom");
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
+        final String constructedUrl = CommonUtils.constructServiceUrl(new DelegatingHttpRequest(request),
+                new DelegatingHttpResponse(response), null, "www.myserver.com",
                 Protocol.SAML11.getArtifactParameterName() , true);
 
         assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
@@ -217,7 +224,8 @@ public final class CommonUtilsTests extends TestCase {
         request.setQueryString("TARGET%3Dthis%26SAMLart%3Dthat%26custom%3Dcustom%20value%20here%26another%3Dgood");
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
+        final String constructedUrl = CommonUtils.constructServiceUrl(new DelegatingHttpRequest(request),
+                new DelegatingHttpResponse(response), null, "www.myserver.com",
                 Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName() , true);
 
         assertEquals("https://www.myserver.com/hello/hithere/?custom=custom+value+here&another=good", constructedUrl);
@@ -231,7 +239,8 @@ public final class CommonUtilsTests extends TestCase {
         request.setQueryString("TARGET=this&SAMLart=that&custom=custom value here&another=good");
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
+        final String constructedUrl = CommonUtils.constructServiceUrl(new DelegatingHttpRequest(request),
+                new DelegatingHttpResponse(response), null, "www.myserver.com",
                 Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName() , false);
 
         assertEquals("https://www.myserver.com/hello/hithere/?custom=custom value here&another=good", constructedUrl);
@@ -245,7 +254,8 @@ public final class CommonUtilsTests extends TestCase {
         request.setQueryString("TARGET=this&SAMLart=that&custom=custom+value+here&another=good");
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
+        final String constructedUrl = CommonUtils.constructServiceUrl(new DelegatingHttpRequest(request),
+                new DelegatingHttpResponse(response), null, "www.myserver.com",
                 Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName() , true);
 
         assertEquals("https://www.myserver.com/hello/hithere/?custom=custom+value+here&another=good", constructedUrl);
@@ -259,7 +269,8 @@ public final class CommonUtilsTests extends TestCase {
         request.setSecure(true);
         request.setServerPort(555);
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null,
+        final String constructedUrl = CommonUtils.constructServiceUrl(new DelegatingHttpRequest(request),
+                new DelegatingHttpResponse(response), null,
                 serverNameList, "service", "ticket", false);
         assertEquals(CONST_MY_URL, constructedUrl);
     }
@@ -279,8 +290,9 @@ public final class CommonUtilsTests extends TestCase {
         request.setScheme("https");
         request.setSecure(true);
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null,
-                "www.amazon.com www.bestbuy.com www.myserver.com", "service", "ticket", false);
+        final String constructedUrl = CommonUtils.constructServiceUrl(new DelegatingHttpRequest(request),
+                new DelegatingHttpResponse(response), null, "www.amazon.com www.bestbuy.com www.myserver.com",
+                "service", "ticket", false);
         assertEquals(CONST_MY_URL, constructedUrl);
     }
 
@@ -291,7 +303,8 @@ public final class CommonUtilsTests extends TestCase {
         request.setScheme("https");
         request.setSecure(true);
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null,
+        final String constructedUrl = CommonUtils.constructServiceUrl(new DelegatingHttpRequest(request),
+                new DelegatingHttpResponse(response), null,
                 "http://www.amazon.com https://www.bestbuy.com https://www.myserver.com", "service", "ticket", false);
         assertEquals(CONST_MY_URL, constructedUrl);
     }

--- a/cas-client-integration-jboss/src/main/java/org/jasig/cas/client/jboss/authentication/WebAuthenticationFilter.java
+++ b/cas-client-integration-jboss/src/main/java/org/jasig/cas/client/jboss/authentication/WebAuthenticationFilter.java
@@ -29,6 +29,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.jasig.cas.client.Protocol;
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
 import org.jasig.cas.client.jaas.AssertionPrincipal;
 import org.jasig.cas.client.util.AbstractCasFilter;
 import org.jasig.cas.client.util.CommonUtils;
@@ -61,7 +62,8 @@ public final class WebAuthenticationFilter extends AbstractCasFilter {
         final HttpServletRequest request = (HttpServletRequest) servletRequest;
         final HttpServletResponse response = (HttpServletResponse) servletResponse;
         final HttpSession session = request.getSession();
-        final String ticket = CommonUtils.safeGetParameter(request, getProtocol().getArtifactParameterName());
+        final String ticket = CommonUtils.safeGetParameter(new DelegatingHttpRequest(request),
+                getProtocol().getArtifactParameterName());
 
         if (session != null && session.getAttribute(CONST_CAS_ASSERTION) == null && ticket != null) {
             try {

--- a/cas-client-integration-jetty/src/main/java/org/jasig/cas/client/jetty/CasAuthenticator.java
+++ b/cas-client-integration-jetty/src/main/java/org/jasig/cas/client/jetty/CasAuthenticator.java
@@ -23,6 +23,8 @@ import org.eclipse.jetty.security.ServerAuthException;
 import org.eclipse.jetty.server.Authentication;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.jasig.cas.client.Protocol;
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
+import org.jasig.cas.client.http.servlet.DelegatingHttpResponse;
 import org.jasig.cas.client.util.CommonUtils;
 import org.jasig.cas.client.util.ReflectUtils;
 import org.jasig.cas.client.validation.AbstractCasProtocolUrlBasedTicketValidator;
@@ -224,8 +226,8 @@ public class CasAuthenticator extends AbstractLifeCycle implements Authenticator
 
     private String serviceUrl(final HttpServletRequest request, final HttpServletResponse response) {
         return CommonUtils.constructServiceUrl(
-                request,
-                response,
+                new DelegatingHttpRequest(request),
+                new DelegatingHttpResponse(response),
                 null,
                 serverNames,
                 protocol.getServiceParameterName(),

--- a/cas-client-integration-tomcat-common/src/main/java/org/jasig/cas/client/tomcat/AbstractLogoutHandler.java
+++ b/cas-client-integration-tomcat-common/src/main/java/org/jasig/cas/client/tomcat/AbstractLogoutHandler.java
@@ -21,6 +21,8 @@ package org.jasig.cas.client.tomcat;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+
+import org.jasig.cas.client.http.servlet.DelegatingHttpResponse;
 import org.jasig.cas.client.util.AbstractCasFilter;
 import org.jasig.cas.client.util.CommonUtils;
 import org.jasig.cas.client.validation.Assertion;
@@ -61,7 +63,7 @@ public abstract class AbstractLogoutHandler implements LogoutHandler {
         final String redirectUrl = constructRedirectUrl(request);
         if (redirectUrl != null) {
             logger.debug("Redirecting to {}", redirectUrl);
-            CommonUtils.sendRedirect(response, redirectUrl);
+            CommonUtils.sendRedirect(new DelegatingHttpResponse(response), redirectUrl);
         }
     }
 

--- a/cas-client-integration-tomcat-common/src/main/java/org/jasig/cas/client/tomcat/AuthenticatorDelegate.java
+++ b/cas-client-integration-tomcat-common/src/main/java/org/jasig/cas/client/tomcat/AuthenticatorDelegate.java
@@ -23,6 +23,9 @@ import java.security.Principal;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
+import org.jasig.cas.client.http.servlet.DelegatingHttpResponse;
 import org.jasig.cas.client.util.AbstractCasFilter;
 import org.jasig.cas.client.util.CommonUtils;
 import org.jasig.cas.client.validation.Assertion;
@@ -85,13 +88,14 @@ public final class AuthenticatorDelegate {
         if (assertion == null) {
             logger.debug("CAS assertion not found in session -- authentication required.");
             final String token = request.getParameter(this.artifactParameterName);
-            final String service = CommonUtils.constructServiceUrl(request, response, this.serviceUrl, this.serverName,
+            final String service = CommonUtils.constructServiceUrl(new DelegatingHttpRequest(request),
+                    new DelegatingHttpResponse(response), this.serviceUrl, this.serverName,
                     this.serviceParameterName, this.artifactParameterName, true);
             if (CommonUtils.isBlank(token)) {
                 final String redirectUrl = CommonUtils.constructRedirectUrl(this.casServerLoginUrl,
                         this.serviceParameterName, service, false, false);
                 logger.debug("Redirecting to {}", redirectUrl);
-                CommonUtils.sendRedirect(response, redirectUrl);
+                CommonUtils.sendRedirect(new DelegatingHttpResponse(response), redirectUrl);
                 return null;
             }
             try {

--- a/cas-client-integration-tomcat-v6/src/main/java/org/jasig/cas/client/tomcat/v6/ProxyCallbackValve.java
+++ b/cas-client-integration-tomcat-v6/src/main/java/org/jasig/cas/client/tomcat/v6/ProxyCallbackValve.java
@@ -23,6 +23,8 @@ import javax.servlet.ServletException;
 import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
+import org.jasig.cas.client.http.servlet.DelegatingHttpResponse;
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorage;
 import org.jasig.cas.client.util.CommonUtils;
 import org.jasig.cas.client.util.ReflectUtils;
@@ -77,7 +79,8 @@ public final class ProxyCallbackValve extends AbstractLifecycleValve {
     public void invoke(final Request request, final Response response) throws IOException, ServletException {
         if (this.proxyCallbackUrl.equals(request.getRequestURI())) {
             logger.debug("Processing proxy callback request.");
-            CommonUtils.readAndRespondToProxyReceptorRequest(request, response, PROXY_GRANTING_TICKET_STORAGE);
+            CommonUtils.readAndRespondToProxyReceptorRequest(new DelegatingHttpRequest(request),
+                    new DelegatingHttpResponse(response), PROXY_GRANTING_TICKET_STORAGE);
             return;
         }
 

--- a/cas-client-integration-tomcat-v6/src/main/java/org/jasig/cas/client/tomcat/v6/SingleSignOutValve.java
+++ b/cas-client-integration-tomcat-v6/src/main/java/org/jasig/cas/client/tomcat/v6/SingleSignOutValve.java
@@ -26,6 +26,8 @@ import org.apache.catalina.SessionEvent;
 import org.apache.catalina.SessionListener;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
+import org.jasig.cas.client.http.servlet.DelegatingHttpResponse;
 import org.jasig.cas.client.session.SessionMappingStorage;
 import org.jasig.cas.client.session.SingleSignOutHandler;
 
@@ -77,7 +79,7 @@ public class SingleSignOutValve extends AbstractLifecycleValve implements Sessio
 
     /** {@inheritDoc} */
     public void invoke(final Request request, final Response response) throws IOException, ServletException {
-        if (this.handler.process(request, response)) {
+        if (this.handler.process(new DelegatingHttpRequest(request), new DelegatingHttpResponse(response))) {
             getNext().invoke(request, response);
         }
     }

--- a/cas-client-integration-tomcat-v7/src/main/java/org/jasig/cas/client/tomcat/v7/ProxyCallbackValve.java
+++ b/cas-client-integration-tomcat-v7/src/main/java/org/jasig/cas/client/tomcat/v7/ProxyCallbackValve.java
@@ -24,6 +24,8 @@ import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
+import org.jasig.cas.client.http.servlet.DelegatingHttpResponse;
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorage;
 import org.jasig.cas.client.util.CommonUtils;
 import org.jasig.cas.client.util.ReflectUtils;
@@ -81,7 +83,8 @@ public final class ProxyCallbackValve extends ValveBase {
     public void invoke(final Request request, final Response response) throws IOException, ServletException {
         if (this.proxyCallbackUrl.equals(request.getRequestURI())) {
             logger.debug("Processing proxy callback request.");
-            CommonUtils.readAndRespondToProxyReceptorRequest(request, response, PROXY_GRANTING_TICKET_STORAGE);
+            CommonUtils.readAndRespondToProxyReceptorRequest(new DelegatingHttpRequest(request),
+                    new DelegatingHttpResponse(response), PROXY_GRANTING_TICKET_STORAGE);
             return;
         }
 

--- a/cas-client-integration-tomcat-v7/src/main/java/org/jasig/cas/client/tomcat/v7/SingleSignOutValve.java
+++ b/cas-client-integration-tomcat-v7/src/main/java/org/jasig/cas/client/tomcat/v7/SingleSignOutValve.java
@@ -27,6 +27,8 @@ import org.apache.catalina.SessionListener;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
+import org.jasig.cas.client.http.servlet.DelegatingHttpResponse;
 import org.jasig.cas.client.session.SessionMappingStorage;
 import org.jasig.cas.client.session.SingleSignOutHandler;
 import org.slf4j.Logger;
@@ -74,7 +76,7 @@ public class SingleSignOutValve extends ValveBase implements SessionListener {
 
     /** {@inheritDoc} */
     public void invoke(final Request request, final Response response) throws IOException, ServletException {
-        if (this.handler.process(request, response)) {
+        if (this.handler.process(new DelegatingHttpRequest(request), new DelegatingHttpResponse(response))) {
             getNext().invoke(request, response);
         }
     }

--- a/cas-client-integration-tomcat-v8/src/main/java/org/jasig/cas/client/tomcat/v8/ProxyCallbackValve.java
+++ b/cas-client-integration-tomcat-v8/src/main/java/org/jasig/cas/client/tomcat/v8/ProxyCallbackValve.java
@@ -24,6 +24,8 @@ import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
+import org.jasig.cas.client.http.servlet.DelegatingHttpResponse;
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorage;
 import org.jasig.cas.client.util.CommonUtils;
 import org.jasig.cas.client.util.ReflectUtils;
@@ -81,7 +83,8 @@ public final class ProxyCallbackValve extends ValveBase {
     public void invoke(final Request request, final Response response) throws IOException, ServletException {
         if (this.proxyCallbackUrl.equals(request.getRequestURI())) {
             logger.debug("Processing proxy callback request.");
-            CommonUtils.readAndRespondToProxyReceptorRequest(request, response, PROXY_GRANTING_TICKET_STORAGE);
+            CommonUtils.readAndRespondToProxyReceptorRequest(new DelegatingHttpRequest(request),
+                    new DelegatingHttpResponse(response), PROXY_GRANTING_TICKET_STORAGE);
             return;
         }
 

--- a/cas-client-integration-tomcat-v8/src/main/java/org/jasig/cas/client/tomcat/v8/SingleSignOutValve.java
+++ b/cas-client-integration-tomcat-v8/src/main/java/org/jasig/cas/client/tomcat/v8/SingleSignOutValve.java
@@ -27,6 +27,8 @@ import org.apache.catalina.SessionListener;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
+import org.jasig.cas.client.http.servlet.DelegatingHttpRequest;
+import org.jasig.cas.client.http.servlet.DelegatingHttpResponse;
 import org.jasig.cas.client.session.SessionMappingStorage;
 import org.jasig.cas.client.session.SingleSignOutHandler;
 import org.slf4j.Logger;
@@ -74,7 +76,7 @@ public class SingleSignOutValve extends ValveBase implements SessionListener {
 
     /** {@inheritDoc} */
     public void invoke(final Request request, final Response response) throws IOException, ServletException {
-        if (this.handler.process(request, response)) {
+        if (this.handler.process(new DelegatingHttpRequest(request), new DelegatingHttpResponse(response))) {
             getNext().invoke(request, response);
         }
     }


### PR DESCRIPTION
This PR introduces an abstraction for HTTP request, response, and session and uses it in `CommonUtils` and the `SingleSignOutHandler`, allowing the common protocol support in those classes to be reused in a non-Servlet context; e.g. in an integration that uses [Undertow](https://github.com/undertow-io/undertow).

If this PR is accepted, it also creates the potential for completely separating the servlet filters and other components in the core module that depend on Servlet API into another module. 

As an added benefit, various unit tests that right now depend on concrete mocks of servlet API classes for tests of rather critical code paths could be rewritten to use interface-based mocks (e.g. via Mockito, jMock, or comparable mocking framework).
