### PR TITLE
3.2.x

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>java-cas-client</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/.settings/org.eclipse.m2e.core.prefs
+++ b/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/cas-client-integration-tomcat-common/pom.xml
+++ b/cas-client-integration-tomcat-common/pom.xml
@@ -20,6 +20,13 @@
             <type>jar</type>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.0</version>
+            <type>jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/cas-client-integration-tomcat-common/src/test/java/org/jasig/cas/client/tomcat/AuthenticatorDelegateTest.java
+++ b/cas-client-integration-tomcat-common/src/test/java/org/jasig/cas/client/tomcat/AuthenticatorDelegateTest.java
@@ -1,0 +1,156 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.cas.client.tomcat;
+
+
+import static java.net.URLEncoder.encode;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import junit.framework.TestCase;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+
+/**
+ * Testing configuration with rules for service redirection. Scenario: server whose IP is 123.12.3.4, hosting an app
+ * running on port 8080, and a CAS server running on 8090. Both apps (/app e /cas) behind reverse http proxy.
+ * 
+ * @author fabiowg
+ */
+public class AuthenticatorDelegateTest extends TestCase {
+
+    private static final String APP_REQUEST_URI = "/app/Screen.action";
+
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        this.request = mock(HttpServletRequest.class);
+
+        this.response = mock(HttpServletResponse.class);
+        when(this.response.encodeURL(anyString())).then(new Answer<String>() {
+
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                return encode((String) invocation.getArguments()[0], "UTF-8");
+            }
+        });
+    }
+
+    public void testRedirectionNoRulesInternalUrl() throws IOException {
+        AuthenticatorDelegate delegate = new AuthenticatorDelegate();
+        delegate.setServerName("123.12.3.4:8080");
+        delegate.setCasServerLoginUrl("https://123.12.3.4:8090/cas/login");
+        delegate.setServiceParameterName("TARGET");
+
+        String requestURL = "https://123.12.3.4:8080" + APP_REQUEST_URI;
+        when(this.request.getRequestURL()).thenReturn(new StringBuffer(requestURL));
+        when(this.request.getRequestURI()).thenReturn(APP_REQUEST_URI);
+
+        delegate.authenticate(this.request, this.response);
+
+        verify(this.response).sendRedirect("https://123.12.3.4:8090/cas/login?TARGET=" + encodeTwice(requestURL));
+    }
+
+    public void testRedirectionRulesPublicReverseProxy() throws IOException {
+        AuthenticatorDelegate delegate = delegateWithRules();
+
+        String requestURL = "https://abc.def.com.br" + APP_REQUEST_URI;
+        when(this.request.getRequestURL()).thenReturn(new StringBuffer(requestURL));
+        when(this.request.getRequestURI()).thenReturn(APP_REQUEST_URI);
+
+        delegate.authenticate(this.request, this.response);
+
+        verify(this.response).sendRedirect("https://abc.def.com.br/cas/login?TARGET=" + encodeTwice(requestURL));
+    }
+
+    public void testRedirectionRulesPrivateReverseProxy() throws IOException {
+        AuthenticatorDelegate delegate = delegateWithRules();
+
+        String requestURL = "https://123.12.3.4" + APP_REQUEST_URI;
+        when(this.request.getRequestURL()).thenReturn(new StringBuffer(requestURL));
+        when(this.request.getRequestURI()).thenReturn(APP_REQUEST_URI);
+
+        delegate.authenticate(this.request, this.response);
+
+        verify(this.response).sendRedirect("https://123.12.3.4/cas/login?TARGET=" + encodeTwice(requestURL));
+    }
+
+    public void testRedirectionRulesPrivateNoReverseProxy() throws IOException {
+        AuthenticatorDelegate delegate = delegateWithRules();
+
+        String requestURL = "https://123.12.3.4:8080" + APP_REQUEST_URI;
+        when(this.request.getRequestURL()).thenReturn(new StringBuffer(requestURL));
+        when(this.request.getRequestURI()).thenReturn(APP_REQUEST_URI);
+
+        delegate.authenticate(this.request, this.response);
+
+        verify(this.response).sendRedirect("https://123.12.3.4:8090/cas/login?TARGET=" + encodeTwice(requestURL));
+    }
+
+    public void testRedirectionRulesTunnel() throws IOException {
+        AuthenticatorDelegate delegate = delegateWithRules();
+
+        String requestURL = "https://localhost:8080" + APP_REQUEST_URI;
+        when(this.request.getRequestURL()).thenReturn(new StringBuffer(requestURL));
+        when(this.request.getRequestURI()).thenReturn(APP_REQUEST_URI);
+
+        delegate.authenticate(this.request, this.response);
+
+        verify(this.response).sendRedirect("https://localhost:8090/cas/login?TARGET=" + encodeTwice(requestURL));
+    }
+
+    public void testRedirectionRulesTunnel2() throws IOException {
+        AuthenticatorDelegate delegate = delegateWithRules();
+
+        String requestURL = "https://localhost:38080" + APP_REQUEST_URI;
+        when(this.request.getRequestURL()).thenReturn(new StringBuffer(requestURL));
+        when(this.request.getRequestURI()).thenReturn(APP_REQUEST_URI);
+
+        delegate.authenticate(this.request, this.response);
+
+        verify(this.response).sendRedirect("https://localhost:38090/cas/login?TARGET=" + encodeTwice(requestURL));
+    }
+
+    private static String encodeTwice(String requestURL) throws UnsupportedEncodingException {
+        return encode(encode(requestURL, "UTF-8"), "UTF-8");
+    }
+
+    private static AuthenticatorDelegate delegateWithRules() {
+        AuthenticatorDelegate delegate = new AuthenticatorDelegate();
+        delegate.setServerName("https?://([^/]+).* $1");
+        delegate.setCasServerLoginUrl("https?://([^:]+):(\\d?)8080.* http://$1:$28090/cas/login || https?://([^/]+).* http://$1/cas/login");
+        delegate.setServiceParameterName("TARGET");
+        return delegate;
+    }
+
+}

--- a/cas-client-integration-tomcat-v6/src/main/java/org/jasig/cas/client/tomcat/v6/AbstractAuthenticator.java
+++ b/cas-client-integration-tomcat-v6/src/main/java/org/jasig/cas/client/tomcat/v6/AbstractAuthenticator.java
@@ -154,8 +154,7 @@ public abstract class AbstractAuthenticator extends AuthenticatorBase implements
             // Authentication sets the response headers for status and redirect if needed
 	        principal = this.delegate.authenticate(request.getRequest(), response);
             if (principal != null) {
-                request.setAuthType(getAuthenticationMethod());
-                request.setUserPrincipal(principal);
+                register(request, response, principal, getAuthenticationMethod(), null, null);
                 result = true;
             }
         } else {

--- a/cas-client-integration-tomcat-v7/src/main/java/org/jasig/cas/client/tomcat/v7/AbstractAuthenticator.java
+++ b/cas-client-integration-tomcat-v7/src/main/java/org/jasig/cas/client/tomcat/v7/AbstractAuthenticator.java
@@ -163,8 +163,7 @@ public abstract class AbstractAuthenticator extends AuthenticatorBase implements
             // Authentication sets the response headers for status and redirect if needed
 	        principal = this.delegate.authenticate(request.getRequest(), response);
             if (principal != null) {
-                request.setAuthType(getAuthenticationMethod());
-                request.setUserPrincipal(principal);
+                register(request, response, principal, getAuthenticationMethod(), null, null);
                 result = true;
             }
         } else {


### PR DESCRIPTION
This commit makes Saml11Authenticator attributes casServerLoginUrl and serverName accept regex rules for resolve service URLs instead of only hard-coded URLs.
Example:

<Valve className="org.jasig.cas.client.tomcat.v7.Saml11Authenticator"
serverName="https?://([^/]+).\* $1"
casServerLoginUrl="https?://([^:]+):(\d?)8080.\* http://$1:$28090/cas/login || https?://([^/]+).\* http://$1/cas/login"


For serverName, it'll resolve to the whole domain or IP, for casServerLoginUrl, it's going to consider if the accessed URLs contains the port 8080, in which case it'll resolve the login url to the (accessed domain or IP):8090/cas/login; any other case it'll resolve simply to the (accessed domain or IP)/cas/login.
