### PR TITLE
change git clone URL in README to reflect new org slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ All client artifacts are published to Maven central. Depending on functionality,
 ## Build [![Build Status](https://travis-ci.org/Jasig/java-cas-client.png?branch=master)](https://travis-ci.org/Jasig/java-cas-client)
 
 ```bash
-git clone git@github.com:Jasig/java-cas-client.git
+git clone git@github.com:apereo/java-cas-client.git
 cd java-cas-client
 mvn clean package
 ```


### PR DESCRIPTION
Looks like this got missed with the change in org name.