### PR TITLE
Wrong Maven groupId in README.md for Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ files in the modules (`cas-client-integration-jboss` and `cas-client-support-dis
 
 ```xml
 <dependency>
-   <groupId>org.jasig.cas</groupId>
+   <groupId>org.jasig.cas.client</groupId>
    <artifactId>cas-client-support-saml</artifactId>
    <version>${java.cas.client.version}</version>
 </dependency>
@@ -46,7 +46,7 @@ files in the modules (`cas-client-integration-jboss` and `cas-client-support-dis
 
 ```xml
 <dependency>
-   <groupId>org.jasig.cas</groupId>
+   <groupId>org.jasig.cas.client</groupId>
    <artifactId>cas-client-support-distributed-ehcache</artifactId>
    <version>${java.cas.client.version}</version>
 </dependency>
@@ -56,7 +56,7 @@ files in the modules (`cas-client-integration-jboss` and `cas-client-support-dis
 
 ```xml
 <dependency>
-   <groupId>org.jasig.cas</groupId>
+   <groupId>org.jasig.cas.client</groupId>
    <artifactId>cas-client-support-distributed-memcached</artifactId>
    <version>${java.cas.client.version}</version>
 </dependency>
@@ -66,7 +66,7 @@ files in the modules (`cas-client-integration-jboss` and `cas-client-support-dis
 
 ```xml
 <dependency>
-   <groupId>org.jasig.cas</groupId>
+   <groupId>org.jasig.cas.client</groupId>
    <artifactId>cas-client-integration-atlassian</artifactId>
    <version>${java.cas.client.version}</version>
 </dependency>
@@ -76,7 +76,7 @@ files in the modules (`cas-client-integration-jboss` and `cas-client-support-dis
 
 ```xml
 <dependency>
-   <groupId>org.jasig.cas</groupId>
+   <groupId>org.jasig.cas.client</groupId>
    <artifactId>cas-client-integration-jboss</artifactId>
    <version>${java.cas.client.version}</version>
 </dependency>
@@ -86,7 +86,7 @@ files in the modules (`cas-client-integration-jboss` and `cas-client-support-dis
 
 ```xml
 <dependency>
-   <groupId>org.jasig.cas</groupId>
+   <groupId>org.jasig.cas.client</groupId>
    <artifactId>cas-client-integration-tomcat-v6</artifactId>
    <version>${java.cas.client.version}</version>
 </dependency>
@@ -96,7 +96,7 @@ files in the modules (`cas-client-integration-jboss` and `cas-client-support-dis
 
 ```xml
 <dependency>
-   <groupId>org.jasig.cas</groupId>
+   <groupId>org.jasig.cas.client</groupId>
    <artifactId>cas-client-integration-tomcat-v7</artifactId>
    <version>${java.cas.client.version}</version>
 </dependency>
@@ -106,7 +106,7 @@ files in the modules (`cas-client-integration-jboss` and `cas-client-support-dis
 
 ```xml
 <dependency>
-   <groupId>org.jasig.cas</groupId>
+   <groupId>org.jasig.cas.client</groupId>
    <artifactId>cas-client-integration-tomcat-v8</artifactId>
    <version>${java.cas.client.version}</version>
 </dependency>


### PR DESCRIPTION
In the README.md, part "Components", the Maven groupId should be "org.jasig.cas.client" for all the components:
https://github.com/apereo/java-cas-client#components
There are some Maven groupId "org.jasig.cas", for exemple for the component cas-client-support-saml
```xml
<dependency>
   <groupId>org.jasig.cas</groupId>
   <artifactId>cas-client-support-saml</artifactId>
   <version>${java.cas.client.version}</version>
</dependency>
```
it should be :
 ```xml
<dependency>
   <groupId>org.jasig.cas.client</groupId>
   <artifactId>cas-client-support-saml</artifactId>
   <version>${java.cas.client.version}</version>
</dependency>
```

