### PR TITLE
The method "parseQuery"  removes the '?' symbol of the Base64 parameters.

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
@@ -18,12 +18,19 @@
  */
 package org.jasig.cas.client.util;
 
-import java.io.*;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
-import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -698,5 +705,25 @@ public final class CommonUtils {
         } catch (final NumberFormatException nfe) {
             return defaultValue;
         }
+    }
+    
+    /**
+     * Counts how many times the character appears in the String. A null or empty String input returns 0.
+     *
+     * @param str  the String to check, may be null
+     * @param character  the character to count
+     * @return the number of occurrences, 0 if either String is null
+     */
+    public static int countMatches(final String str, char character) {
+        if (isEmpty(str)) {
+            return 0;
+        }
+        int count = 0;
+        for (int index = 0; index < str.length(); index++ ) {
+            if (character == str.charAt( index )) {
+                count++;
+            }
+        }
+        return count;
     }
 }

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/URIBuilder.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/URIBuilder.java
@@ -18,6 +18,7 @@
  */
 package org.jasig.cas.client.util;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,7 +117,16 @@ public final class URIBuilder {
                 final String[] parametersArray = queryValue.split("&");
 
                 for (final String parameter : parametersArray) {
-                    final String[] parameterCombo = parameter.split("=");
+                    final String[] parameterCombo;
+                    if ( StringUtils.countMatches( parameter, "=" ) > 1 ) {
+                        int index = parameter.indexOf( '=' );
+                        parameterCombo = new String[2];
+                        parameterCombo[0] = parameter.substring( 0, index );
+                        parameterCombo[1] = parameter.substring( index + 1 );
+                    }
+                    else {
+                        parameterCombo = parameter.split("=");
+                    }
                     if (parameterCombo.length == 2) {
                         list.add(new BasicNameValuePair(parameterCombo[0], parameterCombo[1]));
                     }

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/URIBuilder.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/URIBuilder.java
@@ -18,10 +18,6 @@
  */
 package org.jasig.cas.client.util;
 
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -29,10 +25,12 @@ import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A utility class borrowed from apache http-client to build uris.
@@ -118,7 +116,7 @@ public final class URIBuilder {
 
                 for (final String parameter : parametersArray) {
                     final String[] parameterCombo;
-                    if ( StringUtils.countMatches( parameter, "=" ) > 1 ) {
+                    if ( CommonUtils.countMatches( parameter, '=' ) > 1 ) {
                         int index = parameter.indexOf( '=' );
                         parameterCombo = new String[2];
                         parameterCombo[0] = parameter.substring( 0, index );

--- a/cas-client-core/src/test/java/org/jasig/cas/client/PublicTestHttpServer.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/PublicTestHttpServer.java
@@ -18,11 +18,18 @@
  */
 package org.jasig.cas.client;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.log4j.Logger;
 
 /**
  * @author Scott Battaglia
@@ -33,6 +40,8 @@ public final class PublicTestHttpServer extends Thread {
 
     private static PublicTestHttpServer httpServer;
 
+    private static final Logger LOG = Logger.getLogger( PublicTestHttpServer.class );
+    
     public byte[] content;
 
     private final byte[] header;
@@ -76,11 +85,11 @@ public final class PublicTestHttpServer extends Thread {
     }
 
     public void shutdown() {
-        System.out.println("Shutting down connection on port " + server.getLocalPort());
+        LOG.info("Shutting down connection on port " + server.getLocalPort());
         try {
             this.server.close();
         } catch (final Exception e) {
-            System.err.println(e);
+            LOG.error("Error on shutdown", e);
         }
 
         httpServer = null;
@@ -90,7 +99,7 @@ public final class PublicTestHttpServer extends Thread {
 
         try {
             this.server = new ServerSocket(this.port);
-            System.out.println("Accepting connections on port " + server.getLocalPort());
+            LOG.info("Accepting connections on port " + server.getLocalPort());
             while (true) {
 
                 Socket connection = null;
@@ -127,7 +136,7 @@ public final class PublicTestHttpServer extends Thread {
             } // end while
         } // end try
         catch (final IOException e) {
-            System.err.println("Could not start server. Port Occupied");
+            LOG.error("Could not start server. Port Occupied.", e);
         }
 
     } // end run

--- a/cas-client-core/src/test/java/org/jasig/cas/client/validation/Cas20ProxyTicketValidatorTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/validation/Cas20ProxyTicketValidatorTests.java
@@ -20,9 +20,11 @@ package org.jasig.cas.client.validation;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.jasig.cas.client.PublicTestHttpServer;
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorage;
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorageImpl;
@@ -64,6 +66,7 @@ public final class Cas20ProxyTicketValidatorTests extends AbstractTicketValidato
         this.ticketValidator.setProxyGrantingTicketStorage(getProxyGrantingTicketStorage());
         this.ticketValidator.setProxyRetriever(getProxyRetriever());
         this.ticketValidator.setAllowedProxyChains(new ProxyList(list));
+        Thread.sleep( 2000 );
     }
 
     private ProxyGrantingTicketStorage getProxyGrantingTicketStorage() {

--- a/cas-client-core/src/test/java/org/jasig/cas/client/validation/Cas20ServiceTicketValidatorTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/validation/Cas20ServiceTicketValidatorTests.java
@@ -42,8 +42,6 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
 
     private static final PublicTestHttpServer server = PublicTestHttpServer.instance(8088);
 
-    private static final Logger LOG = Logger.getLogger( Cas20ServiceTicketValidatorTests.class );
-    
     private Cas20ServiceTicketValidator ticketValidator;
 
     private ProxyGrantingTicketStorage proxyGrantingTicketStorage;
@@ -59,16 +57,13 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
 
     @Before
     public void setUp() throws Exception {
-        LOG.info( "Enter in setUp" );
         this.proxyGrantingTicketStorage = getProxyGrantingTicketStorage();
         this.ticketValidator = new Cas20ServiceTicketValidator(CONST_CAS_SERVER_URL_PREFIX + "8088");
         this.ticketValidator.setProxyCallbackUrl("test");
         this.ticketValidator.setProxyGrantingTicketStorage(getProxyGrantingTicketStorage());
         this.ticketValidator.setProxyRetriever(getProxyRetriever());
         this.ticketValidator.setRenew(true);
-        LOG.info( "setUp --> sleep" );
         Thread.sleep( 2000 );
-        LOG.info( "Out of setUp" );
     }
 
     private ProxyGrantingTicketStorage getProxyGrantingTicketStorage() {
@@ -89,7 +84,6 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
 
     @Test
     public void testNoResponse() throws UnsupportedEncodingException {
-        LOG.info( "Enter in testNoResponse" );
         final String RESPONSE = "<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'><cas:authenticationFailure code=\"INVALID_TICKET\">Ticket ST-1856339-aA5Yuvrxzpv8Tau1cYQ7 not recognized</cas:authenticationFailure></cas:serviceResponse>";
         server.content = RESPONSE.getBytes(server.encoding);
         try {
@@ -98,12 +92,10 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
         } catch (final TicketValidationException e) {
             // expected
         }
-        LOG.info( "Out of testNoResponse" );
     }
 
     @Test
     public void testYesResponseButNoPgt() throws TicketValidationException, UnsupportedEncodingException {
-        LOG.info( "Enter in testYesResponseButNoPgt" );
         final String USERNAME = "username";
         final String RESPONSE = "<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'><cas:authenticationSuccess><cas:user>"
                 + USERNAME + "</cas:user></cas:authenticationSuccess></cas:serviceResponse>";
@@ -111,12 +103,10 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
 
         final Assertion assertion = this.ticketValidator.validate("test", "test");
         assertEquals(USERNAME, assertion.getPrincipal().getName());
-        LOG.info( "Out of testYesResponseButNoPgt" );
     }
 
     @Test
     public void testYesResponseWithPgt() throws TicketValidationException, UnsupportedEncodingException {
-        LOG.info( "Enter in testYesResponseWithPgt" );
         final String USERNAME = "username";
         final String PGTIOU = "testPgtIou";
         final String PGT = "test";
@@ -132,12 +122,10 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
         final Assertion assertion = this.ticketValidator.validate("test", "test");
         assertEquals(USERNAME, assertion.getPrincipal().getName());
         //        assertEquals(PGT, assertion.getProxyGrantingTicketId());
-        LOG.info( "Out of testYesResponseWithPgt" );
     }
 
     @Test
     public void testGetAttributes() throws TicketValidationException, UnsupportedEncodingException {
-        LOG.info( "Enter in testGetAttributes" );
         final String USERNAME = "username";
         final String PGTIOU = "testPgtIou";
         final String RESPONSE = "<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'><cas:authenticationSuccess><cas:user>"
@@ -159,12 +147,10 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
             fail("'multivaluedAttribute' attribute expected as List<Object> object.");
         }
         //assertEquals(PGT, assertion.getProxyGrantingTicketId());
-        LOG.info( "Out of testGetAttributes" );
     }
 
     @Test
     public void testInvalidResponse() throws Exception {
-        LOG.info( "Enter in testInvalidResponse" );
         final String RESPONSE = "<root />";
         server.content = RESPONSE.getBytes(server.encoding);
         try {
@@ -173,6 +159,5 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
         } catch (final TicketValidationException e) {
             // expected
         }
-        LOG.info( "Out of testInvalidResponse" );
     }
 }

--- a/cas-client-core/src/test/java/org/jasig/cas/client/validation/Cas20ServiceTicketValidatorTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/validation/Cas20ServiceTicketValidatorTests.java
@@ -19,8 +19,11 @@
 package org.jasig.cas.client.validation;
 
 import static org.junit.Assert.*;
+
 import java.io.UnsupportedEncodingException;
 import java.util.List;
+
+import org.apache.log4j.Logger;
 import org.jasig.cas.client.PublicTestHttpServer;
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorage;
 import org.jasig.cas.client.proxy.ProxyGrantingTicketStorageImpl;
@@ -39,6 +42,8 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
 
     private static final PublicTestHttpServer server = PublicTestHttpServer.instance(8088);
 
+    private static final Logger LOG = Logger.getLogger( Cas20ServiceTicketValidatorTests.class );
+    
     private Cas20ServiceTicketValidator ticketValidator;
 
     private ProxyGrantingTicketStorage proxyGrantingTicketStorage;
@@ -54,12 +59,16 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
 
     @Before
     public void setUp() throws Exception {
+        LOG.info( "Enter in setUp" );
         this.proxyGrantingTicketStorage = getProxyGrantingTicketStorage();
         this.ticketValidator = new Cas20ServiceTicketValidator(CONST_CAS_SERVER_URL_PREFIX + "8088");
         this.ticketValidator.setProxyCallbackUrl("test");
         this.ticketValidator.setProxyGrantingTicketStorage(getProxyGrantingTicketStorage());
         this.ticketValidator.setProxyRetriever(getProxyRetriever());
         this.ticketValidator.setRenew(true);
+        LOG.info( "setUp --> sleep" );
+        Thread.sleep( 2000 );
+        LOG.info( "Out of setUp" );
     }
 
     private ProxyGrantingTicketStorage getProxyGrantingTicketStorage() {
@@ -80,6 +89,7 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
 
     @Test
     public void testNoResponse() throws UnsupportedEncodingException {
+        LOG.info( "Enter in testNoResponse" );
         final String RESPONSE = "<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'><cas:authenticationFailure code=\"INVALID_TICKET\">Ticket ST-1856339-aA5Yuvrxzpv8Tau1cYQ7 not recognized</cas:authenticationFailure></cas:serviceResponse>";
         server.content = RESPONSE.getBytes(server.encoding);
         try {
@@ -88,10 +98,12 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
         } catch (final TicketValidationException e) {
             // expected
         }
+        LOG.info( "Out of testNoResponse" );
     }
 
     @Test
     public void testYesResponseButNoPgt() throws TicketValidationException, UnsupportedEncodingException {
+        LOG.info( "Enter in testYesResponseButNoPgt" );
         final String USERNAME = "username";
         final String RESPONSE = "<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'><cas:authenticationSuccess><cas:user>"
                 + USERNAME + "</cas:user></cas:authenticationSuccess></cas:serviceResponse>";
@@ -99,11 +111,12 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
 
         final Assertion assertion = this.ticketValidator.validate("test", "test");
         assertEquals(USERNAME, assertion.getPrincipal().getName());
-
+        LOG.info( "Out of testYesResponseButNoPgt" );
     }
 
     @Test
     public void testYesResponseWithPgt() throws TicketValidationException, UnsupportedEncodingException {
+        LOG.info( "Enter in testYesResponseWithPgt" );
         final String USERNAME = "username";
         final String PGTIOU = "testPgtIou";
         final String PGT = "test";
@@ -119,10 +132,12 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
         final Assertion assertion = this.ticketValidator.validate("test", "test");
         assertEquals(USERNAME, assertion.getPrincipal().getName());
         //        assertEquals(PGT, assertion.getProxyGrantingTicketId());
+        LOG.info( "Out of testYesResponseWithPgt" );
     }
 
     @Test
     public void testGetAttributes() throws TicketValidationException, UnsupportedEncodingException {
+        LOG.info( "Enter in testGetAttributes" );
         final String USERNAME = "username";
         final String PGTIOU = "testPgtIou";
         final String RESPONSE = "<cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'><cas:authenticationSuccess><cas:user>"
@@ -144,10 +159,12 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
             fail("'multivaluedAttribute' attribute expected as List<Object> object.");
         }
         //assertEquals(PGT, assertion.getProxyGrantingTicketId());
+        LOG.info( "Out of testGetAttributes" );
     }
 
     @Test
     public void testInvalidResponse() throws Exception {
+        LOG.info( "Enter in testInvalidResponse" );
         final String RESPONSE = "<root />";
         server.content = RESPONSE.getBytes(server.encoding);
         try {
@@ -156,5 +173,6 @@ public final class Cas20ServiceTicketValidatorTests extends AbstractTicketValida
         } catch (final TicketValidationException e) {
             // expected
         }
+        LOG.info( "Out of testInvalidResponse" );
     }
 }


### PR DESCRIPTION
The method "parseQuery"  removes the '?' symbol of the Base64 parameters.

The first commit use Apache Commons Lang.
