### PR TITLE
Log an error message if CAS principal has no corresponding Confluence principal

### DIFF
--- a/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/atlassian/ConfluenceCasAuthenticator.java
+++ b/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/atlassian/ConfluenceCasAuthenticator.java
@@ -61,7 +61,7 @@ public final class ConfluenceCasAuthenticator extends ConfluenceAuthenticator {
 
             // user doesn't exist 
             if (p == null) {
-                LOGGER.error("Principal is null for " + assertion.getPrincipal().getName());
+                LOGGER.error("Principal is null for ", assertion.getPrincipal().getName());
             }
 
             LOGGER.debug("Logging in [{}] from CAS.", p.getName());

--- a/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/atlassian/ConfluenceCasAuthenticator.java
+++ b/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/atlassian/ConfluenceCasAuthenticator.java
@@ -59,6 +59,11 @@ public final class ConfluenceCasAuthenticator extends ConfluenceAuthenticator {
         if (assertion != null) {
             final Principal p = getUser(assertion.getPrincipal().getName());
 
+            // user doesn't exist 
+            if (p == null) {
+                LOGGER.error("Principal is null for " + assertion.getPrincipal().getName());
+            }
+
             LOGGER.debug("Logging in [{}] from CAS.", p.getName());
 
             session.setAttribute(LOGGED_IN_KEY, p);


### PR DESCRIPTION
If there is no Confluence principal for the CAS principal log an error message with the CAS user name.
