### PR TITLE
add setter to ignoreUrlPatternMatcherStrategyClass

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/authentication/AuthenticationFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/authentication/AuthenticationFilter.java
@@ -212,4 +212,10 @@ public class AuthenticationFilter extends AbstractCasFilter {
         final String requestUri = urlBuffer.toString();
         return this.ignoreUrlPatternMatcherStrategyClass.matches(requestUri);
     }
+
+    public final void setIgnoreUrlPatternMatcherStrategyClass(
+            final UrlPatternMatcherStrategy ignoreUrlPatternMatcherStrategyClass) {
+        this.ignoreUrlPatternMatcherStrategyClass = ignoreUrlPatternMatcherStrategyClass;
+    }
+
 }


### PR DESCRIPTION
when use Spring, the following injection fails due to lack of ignoreUrlPatternMatcherStrategyClass's setter method.
`
<bean name="regexUrlPatternMatcherStrategy" class="org.jasig.cas.client.authentication.RegexUrlPatternMatcherStrategy">
    <constructor-arg name="pattern"	value="[a-zA-z]+://[A-Za-z0-9_\-\.]+/($|resources/.*)" />
</bean>`

`
<bean name="casAuthenticationFilter" class="org.jasig.cas.client.authentication.AuthenticationFilter" p:ignoreUrlPatternMatcherStrategyClass-ref="regexUrlPatternMatcherStrategy" />`

