### PR TITLE
Fix missing parameter key in service url (#208)

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
@@ -345,8 +345,20 @@ public final class CommonUtils {
         final List<String> serviceParameterNames = Arrays.asList(serviceParameterName.split(","));
         if (!serviceParameterNames.isEmpty() && !originalRequestUrl.getQueryParams().isEmpty()) {
             for (final URIBuilder.BasicNameValuePair pair : originalRequestUrl.getQueryParams()) {
-                if (!pair.getName().equals(artifactParameterName) && !serviceParameterNames.contains(pair.getName())) {
-                    builder.addParameter(pair.getName(), pair.getValue());
+                String name = pair.getName();
+                if (!name.equals(artifactParameterName) && !serviceParameterNames.contains(name)) {
+                    if (name.contains("&") || name.contains("=") ){
+                        URIBuilder encodedParamBuilder = new URIBuilder();
+                        encodedParamBuilder.setParameters(name);
+                        for (final URIBuilder.BasicNameValuePair pair2 :encodedParamBuilder.getQueryParams()){
+                            String name2 = pair2.getName();
+                            if (!name2.equals(artifactParameterName) && !serviceParameterNames.contains(name2)) {
+                                builder.addParameter(name2, pair2.getValue());
+                            }
+                        }
+                    } else {
+                        builder.addParameter(name, pair.getValue());
+                    }
                 }
             }
         }

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/URIBuilder.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/URIBuilder.java
@@ -112,13 +112,14 @@ public final class URIBuilder {
             final Charset utf8 = Charset.forName("UTF-8");
             if (query != null && !query.isEmpty()) {
                 final List<BasicNameValuePair> list = new ArrayList<BasicNameValuePair>();
-                final String queryValue = URLDecoder.decode(query, utf8.name());
-                final String[] parametersArray = queryValue.split("&");
+                final String[] parametersArray = query.split("&");
 
                 for (final String parameter : parametersArray) {
                     final String[] parameterCombo = parameter.split("=");
-                    if (parameterCombo.length == 2) {
-                        list.add(new BasicNameValuePair(parameterCombo[0], parameterCombo[1]));
+                    if (parameterCombo.length >= 1) {
+                        final String key = URLDecoder.decode(parameterCombo[0], utf8.name());
+                        final String val = parameterCombo.length == 2 ? URLDecoder.decode(parameterCombo[1], utf8.name()) : "";
+                        list.add(new BasicNameValuePair(key, val));
                     }
                 }
                 return list;

--- a/cas-client-core/src/test/java/org/jasig/cas/client/util/URIBuilderTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/util/URIBuilderTests.java
@@ -280,7 +280,7 @@ public class URIBuilderTests {
     @Test
     public void parse() {
         URIBuilder builder = new URIBuilder()
-                .digestURI(URI.create("http://apache.org/shindig?foo=bar%26baz&foo=three#blah"));
+                .digestURI(URI.create("http://apache.org/shindig?foo=bar%26baz&foo=three%3Dbaz#blah"));
 
         assertEquals("http", builder.getScheme());
         assertEquals("apache.org", builder.getHost());
@@ -288,8 +288,8 @@ public class URIBuilderTests {
 
         List<URIBuilder.BasicNameValuePair> list = builder.getQueryParams();
         for (URIBuilder.BasicNameValuePair pair : list) {
-            assertEquals(pair.getName(), "foo");
-            assertTrue(pair.getValue().equals("three") || pair.getValue().equals("bar"));
+            assertEquals("foo", pair.getName());
+            assertTrue(pair.getValue().equals("three=baz") || pair.getValue().equals("bar&baz"));
         }
         assertEquals(list.size(), 2);
         assertEquals("blah", builder.getFragment());


### PR DESCRIPTION
I Fixed missing parameter key in service url when the value was null.(#208)
The code before fix, query parameter was decorded before parse to key-value pair. it is bug.

In testcase, query parameter is "foo = bar% 26 baz",
And key "foo" value expected "bar" is correct, but it should be "bar & baz".
