### PR TITLE
Add JIRA Rest API support

### DIFF
--- a/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/atlassian/Jira44CasAuthenticator.java
+++ b/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/atlassian/Jira44CasAuthenticator.java
@@ -19,6 +19,7 @@
 package org.jasig.cas.client.integration.atlassian;
 
 import com.atlassian.jira.security.login.JiraSeraphAuthenticator;
+import com.atlassian.seraph.auth.AuthenticationContextAwareAuthenticator;
 import com.atlassian.seraph.auth.AuthenticatorException;
 import com.atlassian.seraph.auth.LoginReason;
 import java.security.Principal;
@@ -40,6 +41,7 @@ import org.slf4j.LoggerFactory;
  * @version $Revision$ $Date$
  * @since 3.3.0
  */
+@AuthenticationContextAwareAuthenticator
 public final class Jira44CasAuthenticator extends JiraSeraphAuthenticator {
 
     /** Jira43CasAuthenticator.java */


### PR DESCRIPTION
new JIRA 6 has rest api begin with url /rest when I use cas authentication filter which skip filter /rest ,there will be thrown exception:

```
java.lang.NullPointerException
    at com.atlassian.jira.security.login.JiraSeraphAuthenticator.getUserFromBasicAuthentication(JiraSeraphAuthenticator.java:149) 
    at com.atlassian.seraph.auth.DefaultAuthenticator.getUser(DefaultAuthenticator.java:339) [atlassian-seraph-3.0.3.jar:?]
    at org.jasig.cas.client.integration.atlassian.Jira44CasAuthenticator.getUser(Jira44CasAuthenticator.java:76) [cas-client-integration-atlassian-3.4.1.jar:3.4.1] 
    at com.atlassian.seraph.auth.AbstractAuthenticator.getUser(AbstractAuthenticator.java:45) [atlassian-seraph-3.0.3.jar:?]
    at com.atlassian.seraph.filter.BaseLoginFilter$SecurityHttpRequestWrapper.getUserPrincipal(BaseLoginFilter.java:238) [atlassian-seraph-3.0.3.jar:?]
    at com.atlassian.seraph.filter.BaseLoginFilter$SecurityHttpRequestWrapper.getRemoteUser(BaseLoginFilter.java:225) [atlassian-seraph-3.0.3.jar:?]
    at javax.servlet.http.HttpServletRequestWrapper.getRemoteUser(HttpServletRequestWrapper.java:168) [servlet-api.jar:?]
    at com.atlassian.jira.web.filters.accesslog.AccessLogFilter.preFilterCallStep(AccessLogFilter.java:175) [classes/:?]
    at com.atlassian.jira.web.filters.accesslog.AccessLogFilter.executeRequest(AccessLogFilter.java:86) [classes/:?]
    at com.atlassian.jira.web.filters.accesslog.AccessLogFilter.doFilter(AccessLogFilter.java:78) [classes/:?]
```

After hard debug work I found key program flow different from default authenitcator  :

in `com.atlassian.seraph.filter.BaseLoginFilter#SecurityHttpRequestWrapper#getUserPrincipal()`

```
public Principal getUserPrincipal() {
            return BaseLoginFilter.this.getAuthenticator().getClass().isAnnotationPresent(AuthenticationContextAwareAuthenticator.class)?BaseLoginFilter.this.getAuthenticationContext().getUser():BaseLoginFilter.this.getAuthenticator().getUser(this.delegateHttpServletRequest);
        }
```

The `AuthenticationContextAwareAuthenticator` annotation cause different flow.

So, add `AuthenticationContextAwareAuthenticator` annotation can slow problem.