### PR TITLE
Improve error logging when getting response from CAS server fails

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
@@ -20,10 +20,11 @@ package org.jasig.cas.client.util;
 
 import java.io.*;
 import java.net.HttpURLConnection;
-import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.*;
+
+import javax.net.ssl.SSLException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -397,11 +398,11 @@ public final class CommonUtils {
      */
     @Deprecated
     public static String getResponseFromServer(final String constructedUrl, final String encoding) {
-        try {
+    	try {
             return getResponseFromServer(new URL(constructedUrl), DEFAULT_URL_CONNECTION_FACTORY, encoding);
-        } catch (final Exception e) {
-            throw new RuntimeException(e);
-        }
+        } catch (final IOException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }  
     }
 
     @Deprecated
@@ -419,7 +420,7 @@ public final class CommonUtils {
      */
     public static String getResponseFromServer(final URL constructedUrl, final HttpURLConnectionFactory factory,
             final String encoding) {
-
+    	
         HttpURLConnection conn = null;
         InputStreamReader in = null;
         try {
@@ -438,8 +439,14 @@ public final class CommonUtils {
             }
 
             return builder.toString();
-        } catch (final Exception e) {
-            LOGGER.error(e.getMessage(), e);
+        } catch (final RuntimeException e) {
+        	throw e;
+        } catch (final SSLException e) {
+            LOGGER.error("SSL error getting response from host: {} : Error Message: {}", constructedUrl.getHost(), e.getMessage(), e);
+            throw new RuntimeException(e);
+        } catch (final IOException e) {
+            LOGGER.error("Error getting response from host: [{}] with path: [{}] and protocol: [{}] Error Message: {}",
+            		constructedUrl.getHost(), constructedUrl.getPath(), constructedUrl.getProtocol(), e.getMessage(), e);
             throw new RuntimeException(e);
         } finally {
             closeQuietly(in);
@@ -468,7 +475,7 @@ public final class CommonUtils {
     public static void sendRedirect(final HttpServletResponse response, final String url) {
         try {
             response.sendRedirect(url);
-        } catch (final Exception e) {
+        } catch (final IOException e) {
             LOGGER.warn(e.getMessage(), e);
         }
 
@@ -699,4 +706,5 @@ public final class CommonUtils {
             return defaultValue;
         }
     }
+
 }


### PR DESCRIPTION
This logs some information about the host being accessed when an SSL error occurs and it logs the host, path and protocol when any other error occurs. This shouldn't leak any semi-sensitive info to the logs (e.g. a service ticket) but it should make it more obvious where the client is going (usually it's the cas server but that can be different in different environments and having more info makes it easier to track down a mis-configuration. 