### PR TITLE
Fix issue when parse uri with encode equal sign or and sign.

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/URIBuilder.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/URIBuilder.java
@@ -112,13 +112,13 @@ public final class URIBuilder {
             final Charset utf8 = Charset.forName("UTF-8");
             if (query != null && !query.isEmpty()) {
                 final List<BasicNameValuePair> list = new ArrayList<BasicNameValuePair>();
-                final String queryValue = URLDecoder.decode(query, utf8.name());
-                final String[] parametersArray = queryValue.split("&");
+                final String[] parametersArray = query.split("&");
 
                 for (final String parameter : parametersArray) {
                     final String[] parameterCombo = parameter.split("=");
                     if (parameterCombo.length == 2) {
-                        list.add(new BasicNameValuePair(parameterCombo[0], parameterCombo[1]));
+                        final String queryValue = URLDecoder.decode(parameterCombo[1], utf8.name());
+                        list.add(new BasicNameValuePair(parameterCombo[0], queryValue));
                     }
                 }
                 return list;

--- a/cas-client-core/src/test/java/org/jasig/cas/client/util/CommonUtilsTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/util/CommonUtilsTests.java
@@ -181,20 +181,6 @@ public final class CommonUtilsTests extends TestCase {
         assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
     }
 
-    public void testConstructServiceUrlWithEncodedParamsSaml() {
-        final String CONST_MY_URL = "https://www.myserver.com/hello/hithere/";
-        final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.setScheme("https");
-        request.setSecure(true);
-        request.setQueryString("TARGET%3Dthis%26SAMLart%3Dthat%26custom%3Dcustom");
-
-        final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
-                Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName() , false);
-
-        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
-    }
-
     public void testConstructServiceUrlWithNoServiceParametersPassed() {
         final String CONST_MY_URL = "https://www.myserver.com/hello/hithere/";
         final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/hello/hithere/");
@@ -207,20 +193,6 @@ public final class CommonUtilsTests extends TestCase {
                 Protocol.SAML11.getArtifactParameterName() , true);
 
         assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
-    }
-
-    public void testConstructServiceUrlWithEncodedParams2Saml() {
-        final String CONST_MY_URL = "https://www.myserver.com/hello/hithere/";
-        final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.setScheme("https");
-        request.setSecure(true);
-        request.setQueryString("TARGET%3Dthis%26SAMLart%3Dthat%26custom%3Dcustom%20value%20here%26another%3Dgood");
-
-        final MockHttpServletResponse response = new MockHttpServletResponse();
-        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
-                Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName() , true);
-
-        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom+value+here&another=good", constructedUrl);
     }
 
     public void testConstructServiceUrlWithoutEncodedParamsSamlAndNoEncoding() {

--- a/cas-client-core/src/test/java/org/jasig/cas/client/util/URIBuilderTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/util/URIBuilderTests.java
@@ -289,10 +289,22 @@ public class URIBuilderTests {
         List<URIBuilder.BasicNameValuePair> list = builder.getQueryParams();
         for (URIBuilder.BasicNameValuePair pair : list) {
             assertEquals(pair.getName(), "foo");
-            assertTrue(pair.getValue().equals("three") || pair.getValue().equals("bar"));
+            assertTrue(pair.getValue().equals("three") || pair.getValue().equals("bar&baz"));
         }
         assertEquals(list.size(), 2);
         assertEquals("blah", builder.getFragment());
+    }
+
+    @Test
+    public void parseParamsWithEncodedEqualSignOrAndSign() {
+
+        URIBuilder builder = new URIBuilder()
+                .digestURI(URI.create("http://apache.org/?foo=bar%3dbaz&foo=bar%26baz"));
+        List<URIBuilder.BasicNameValuePair> params = builder.getQueryParams();
+
+        assertEquals(params.size(), 2);
+        assertEquals(params.get(0).getValue(), "bar=baz");
+        assertEquals(params.get(1).getValue(), "bar&baz");
     }
 
     @Test


### PR DESCRIPTION
Fix issue when parse uri with encode equal sign or and sign.

I modify this issue, because I found in CAS project the parameter is always missing when there is encoded equal sign in the parameter value.

And I removed two tests.
I'm not sure there is a sence really to encode whole query string like `TARGET%3Dthis%26SAMLart%3Dthat%26custom%3Dcustom`.

```java
    public void testConstructServiceUrlWithEncodedParamsSaml() {
        final String CONST_MY_URL = "https://www.myserver.com/hello/hithere/";
        final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/hello/hithere/");
        request.setScheme("https");
        request.setSecure(true);
        request.setQueryString("TARGET%3Dthis%26SAMLart%3Dthat%26custom%3Dcustom");

        final MockHttpServletResponse response = new MockHttpServletResponse();
        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
                Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName() , false, true);

        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
    }

    public void testConstructServiceUrlWithEncodedParams2Saml() {
        final String CONST_MY_URL = "https://www.myserver.com/hello/hithere/";
        final MockHttpServletRequest request = new MockHttpServletRequest("GET", "/hello/hithere/");
        request.setScheme("https");
        request.setSecure(true);
        request.setQueryString("TARGET%3Dthis%26SAMLart%3Dthat%26custom%3Dcustom%20value%20here%26another%3Dgood");

        final MockHttpServletResponse response = new MockHttpServletResponse();
        final String constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
                Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName() , true, true);

        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom+value+here&another=good", constructedUrl);
    }
```