### PR TITLE
Add option to prevent entity stream consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ The `SingleSignOutFilter` can affect character encoding. This becomes most obvio
 | `relayStateParameterName` | Defaults to `RelayState` | No
 | `eagerlyCreateSessions` | Defaults to `true` | No
 | `artifactParameterOverPost` | Defaults to  `false` | No
-| `logoutPath` | The path which is expected to receive logout callback requests from the CAS server. This is necessary if your app needs access to the raw input stream when handling form posts. If not configured, the default behavior will check every form post for a logout parameter. | No
+| `logoutCallbackPath` | The path which is expected to receive logout callback requests from the CAS server. This is necessary if your app needs access to the raw input stream when handling form posts. If not configured, the default behavior will check every form post for a logout parameter. | No
 | `casServerUrlPrefix` | URL to root of CAS Web application context. | Yes
 
 <a name="cas-protocol"></a>

--- a/README.md
+++ b/README.md
@@ -663,6 +663,7 @@ The `SingleSignOutFilter` can affect character encoding. This becomes most obvio
 | `relayStateParameterName` | Defaults to `RelayState` | No
 | `eagerlyCreateSessions` | Defaults to `true` | No
 | `artifactParameterOverPost` | Defaults to  `false` | No
+| `logoutPath` | The path which will receive logout callback requests from the CAS server. This is necessary if your app needs access to the raw input stream when handling form posts. If not configured, the default behavior will check every request for a logout parameter. | No
 | `casServerUrlPrefix` | URL to root of CAS Web application context. | Yes
 
 <a name="cas-protocol"></a>

--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ The `SingleSignOutFilter` can affect character encoding. This becomes most obvio
 | `relayStateParameterName` | Defaults to `RelayState` | No
 | `eagerlyCreateSessions` | Defaults to `true` | No
 | `artifactParameterOverPost` | Defaults to  `false` | No
-| `logoutPath` | The path which will receive logout callback requests from the CAS server. This is necessary if your app needs access to the raw input stream when handling form posts. If not configured, the default behavior will check every request for a logout parameter. | No
+| `logoutPath` | The path which is expected to receive logout callback requests from the CAS server. This is necessary if your app needs access to the raw input stream when handling form posts. If not configured, the default behavior will check every form post for a logout parameter. | No
 | `casServerUrlPrefix` | URL to root of CAS Web application context. | Yes
 
 <a name="cas-protocol"></a>

--- a/cas-client-core/src/main/java/org/jasig/cas/client/configuration/ConfigurationKeys.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/configuration/ConfigurationKeys.java
@@ -78,5 +78,5 @@ public interface ConfigurationKeys {
     ConfigurationKey<Class<? extends Cas20ServiceTicketValidator>> TICKET_VALIDATOR_CLASS = new ConfigurationKey<Class<? extends Cas20ServiceTicketValidator>>("ticketValidatorClass", null);
     ConfigurationKey<String> PROXY_CALLBACK_URL = new ConfigurationKey<String>("proxyCallbackUrl", null);
     ConfigurationKey<String> RELAY_STATE_PARAMETER_NAME = new ConfigurationKey<String>("relayStateParameterName", "RelayState");
-    ConfigurationKey<String> LOGOUT_PATH = new ConfigurationKey<String>("logoutPath", null);
+    ConfigurationKey<String> LOGOUT_CALLBACK_PATH = new ConfigurationKey<String>("logoutCallbackPath", null);
 }

--- a/cas-client-core/src/main/java/org/jasig/cas/client/configuration/ConfigurationKeys.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/configuration/ConfigurationKeys.java
@@ -78,4 +78,5 @@ public interface ConfigurationKeys {
     ConfigurationKey<Class<? extends Cas20ServiceTicketValidator>> TICKET_VALIDATOR_CLASS = new ConfigurationKey<Class<? extends Cas20ServiceTicketValidator>>("ticketValidatorClass", null);
     ConfigurationKey<String> PROXY_CALLBACK_URL = new ConfigurationKey<String>("proxyCallbackUrl", null);
     ConfigurationKey<String> RELAY_STATE_PARAMETER_NAME = new ConfigurationKey<String>("relayStateParameterName", "RelayState");
+    ConfigurationKey<String> LOGOUT_PATH = new ConfigurationKey<String>("logoutPath", null);
 }

--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutFilter.java
@@ -48,6 +48,7 @@ public final class SingleSignOutFilter extends AbstractConfigurationFilter {
             setLogoutParameterName(getString(ConfigurationKeys.LOGOUT_PARAMETER_NAME));
             setRelayStateParameterName(getString(ConfigurationKeys.RELAY_STATE_PARAMETER_NAME));
             setCasServerUrlPrefix(getString(ConfigurationKeys.CAS_SERVER_URL_PREFIX));
+            setLogoutPath(getString(ConfigurationKeys.LOGOUT_PATH));
             HANDLER.setArtifactParameterOverPost(getBoolean(ConfigurationKeys.ARTIFACT_PARAMETER_OVER_POST));
             HANDLER.setEagerlyCreateSessions(getBoolean(ConfigurationKeys.EAGERLY_CREATE_SESSIONS));
         }
@@ -69,6 +70,10 @@ public final class SingleSignOutFilter extends AbstractConfigurationFilter {
 
     public void setCasServerUrlPrefix(final String casServerUrlPrefix) {
         HANDLER.setCasServerUrlPrefix(casServerUrlPrefix);
+    }
+
+    public void setLogoutPath(String logoutPath) {
+        HANDLER.setLogoutPath(logoutPath);
     }
 
     public void setSessionMappingStorage(final SessionMappingStorage storage) {

--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutFilter.java
@@ -48,7 +48,7 @@ public final class SingleSignOutFilter extends AbstractConfigurationFilter {
             setLogoutParameterName(getString(ConfigurationKeys.LOGOUT_PARAMETER_NAME));
             setRelayStateParameterName(getString(ConfigurationKeys.RELAY_STATE_PARAMETER_NAME));
             setCasServerUrlPrefix(getString(ConfigurationKeys.CAS_SERVER_URL_PREFIX));
-            setLogoutPath(getString(ConfigurationKeys.LOGOUT_PATH));
+            setLogoutCallbackPath(getString(ConfigurationKeys.LOGOUT_CALLBACK_PATH));
             HANDLER.setArtifactParameterOverPost(getBoolean(ConfigurationKeys.ARTIFACT_PARAMETER_OVER_POST));
             HANDLER.setEagerlyCreateSessions(getBoolean(ConfigurationKeys.EAGERLY_CREATE_SESSIONS));
         }
@@ -72,8 +72,8 @@ public final class SingleSignOutFilter extends AbstractConfigurationFilter {
         HANDLER.setCasServerUrlPrefix(casServerUrlPrefix);
     }
 
-    public void setLogoutPath(String logoutPath) {
-        HANDLER.setLogoutPath(logoutPath);
+    public void setLogoutCallbackPath(String logoutCallbackPath) {
+        HANDLER.setLogoutCallbackPath(logoutCallbackPath);
     }
 
     public void setSessionMappingStorage(final SessionMappingStorage storage) {

--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHandler.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHandler.java
@@ -173,7 +173,7 @@ public final class SingleSignOutHandler {
     private boolean isLogoutRequest(final HttpServletRequest request) {
         if ("POST".equalsIgnoreCase(request.getMethod())) {
             return !isMultipartRequest(request)
-                    && pathMatches(request)
+                    && pathEligibleForLogout(request)
                     && CommonUtils.isNotBlank(CommonUtils.safeGetParameter(request, this.logoutParameterName,
                     this.safeParameters));
         }
@@ -184,7 +184,7 @@ public final class SingleSignOutHandler {
         return false;
     }
 
-    private boolean pathMatches(HttpServletRequest request) {
+    private boolean pathEligibleForLogout(HttpServletRequest request) {
         return logoutPath == null || logoutPath.equals(getPath(request));
     }
 

--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHandler.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHandler.java
@@ -189,11 +189,7 @@ public final class SingleSignOutHandler {
     }
 
     private String getPath(HttpServletRequest request) {
-        return request.getServletPath() + nullToEmpty(request.getPathInfo());
-    }
-
-    private String nullToEmpty(String string) {
-        return string == null ? "" : string;
+        return request.getServletPath() + CommonUtils.nullToEmpty(request.getPathInfo());
     }
 
     /**

--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHandler.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHandler.java
@@ -66,8 +66,8 @@ public final class SingleSignOutHandler {
     /** The prefix url of the CAS server */
     private String casServerUrlPrefix = "";
 
-    /** The logout path configured at the CAS server, if there is one */
-    private String logoutPath;
+    /** The logout callback path configured at the CAS server, if there is one */
+    private String logoutCallbackPath;
 
     private boolean artifactParameterOverPost = false;
 
@@ -111,10 +111,10 @@ public final class SingleSignOutHandler {
     }
 
     /**
-     * @param logoutPath The logout path configured at the CAS server.
+     * @param logoutCallbackPath The logout callback path configured at the CAS server.
      */
-    public void setLogoutPath(String logoutPath) {
-        this.logoutPath = logoutPath;
+    public void setLogoutCallbackPath(String logoutCallbackPath) {
+        this.logoutCallbackPath = logoutCallbackPath;
     }
 
     /**
@@ -185,7 +185,7 @@ public final class SingleSignOutHandler {
     }
 
     private boolean pathEligibleForLogout(HttpServletRequest request) {
-        return logoutPath == null || logoutPath.equals(getPath(request));
+        return logoutCallbackPath == null || logoutCallbackPath.equals(getPath(request));
     }
 
     private String getPath(HttpServletRequest request) {

--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHandler.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHandler.java
@@ -66,6 +66,9 @@ public final class SingleSignOutHandler {
     /** The prefix url of the CAS server */
     private String casServerUrlPrefix = "";
 
+    /** The logout path configured at the CAS server, if there is one */
+    private String logoutPath;
+
     private boolean artifactParameterOverPost = false;
 
     private boolean eagerlyCreateSessions = true;
@@ -106,7 +109,14 @@ public final class SingleSignOutHandler {
     public void setCasServerUrlPrefix(final String casServerUrlPrefix) {
         this.casServerUrlPrefix = casServerUrlPrefix;
     }
-    
+
+    /**
+     * @param logoutPath The logout path configured at the CAS server.
+     */
+    public void setLogoutPath(String logoutPath) {
+        this.logoutPath = logoutPath;
+    }
+
     /**
      * @param name Name of parameter containing the state of the CAS server webflow.
      */
@@ -163,6 +173,7 @@ public final class SingleSignOutHandler {
     private boolean isLogoutRequest(final HttpServletRequest request) {
         if ("POST".equalsIgnoreCase(request.getMethod())) {
             return !isMultipartRequest(request)
+                    && pathMatches(request)
                     && CommonUtils.isNotBlank(CommonUtils.safeGetParameter(request, this.logoutParameterName,
                     this.safeParameters));
         }
@@ -172,7 +183,19 @@ public final class SingleSignOutHandler {
         }
         return false;
     }
-    
+
+    private boolean pathMatches(HttpServletRequest request) {
+        return logoutPath == null || logoutPath.equals(getPath(request));
+    }
+
+    private String getPath(HttpServletRequest request) {
+        return request.getServletPath() + nullToEmpty(request.getPathInfo());
+    }
+
+    private String nullToEmpty(String string) {
+        return string == null ? "" : string;
+    }
+
     /**
      * Process a request regarding the SLO process: record the session or destroy it.
      *

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
@@ -719,4 +719,15 @@ public final class CommonUtils {
         }
     }
 
+    /**
+     * Returns the string as-is, unless it's <code>null</code>;
+     * in this case an empty string is returned.
+     *
+     * @param string a possibly <code>null</code> string
+     * @return a non-<code>null</code> string
+     */
+    public static String nullToEmpty(String string) {
+        return string == null ? "" : string;
+    }
+
 }

--- a/cas-client-core/src/test/java/org/jasig/cas/client/session/SingleSignOutHandlerTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/session/SingleSignOutHandlerTests.java
@@ -116,13 +116,36 @@ public final class SingleSignOutHandlerTests {
 
     @Test
     public void backChannelLogoutOK() {
+        final MockHttpSession session = doBackChannelLogout();
+        assertFalse(handler.process(request, response));
+        assertTrue(session.isInvalid());
+    }
+
+    @Test
+    public void backChannelLogoutDoesDoesNotRunIfLogoutPathDoesNotMatch() {
+        handler.setLogoutPath("/logout");
+        request.setServletPath("/not-a-logout");
+        final MockHttpSession session = doBackChannelLogout();
+        assertTrue(handler.process(request, response));
+        assertFalse(session.isInvalid());
+    }
+
+    @Test
+    public void backChannelLogoutRunsWhenLogoutPathDoesMatch() {
+        handler.setLogoutPath("/logout");
+        request.setServletPath("/logout");
+        final MockHttpSession session = doBackChannelLogout();
+        assertFalse(handler.process(request, response));
+        assertTrue(session.isInvalid());
+    }
+
+    private MockHttpSession doBackChannelLogout() {
         final String logoutMessage = LogoutMessageGenerator.generateBackChannelLogoutMessage(TICKET);
         request.setParameter(LOGOUT_PARAMETER_NAME, logoutMessage);
         request.setMethod("POST");
         final MockHttpSession session = new MockHttpSession();
         handler.getSessionMappingStorage().addSessionById(TICKET, session);
-        assertFalse(handler.process(request, response));
-        assertTrue(session.isInvalid());
+        return session;
     }
 
     @Test

--- a/cas-client-core/src/test/java/org/jasig/cas/client/session/SingleSignOutHandlerTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/session/SingleSignOutHandlerTests.java
@@ -123,7 +123,7 @@ public final class SingleSignOutHandlerTests {
 
     @Test
     public void backChannelLogoutDoesNotRunIfPathIsNotEligibleForLogout() {
-        handler.setLogoutPath("/logout");
+        handler.setLogoutCallbackPath("/logout");
         request.setServletPath("/not-a-logout");
         final MockHttpSession session = doBackChannelLogout();
         assertTrue(handler.process(request, response));
@@ -132,7 +132,7 @@ public final class SingleSignOutHandlerTests {
 
     @Test
     public void backChannelLogoutRunsIfPathEqualsLogoutPath() {
-        handler.setLogoutPath("/logout");
+        handler.setLogoutCallbackPath("/logout");
         request.setServletPath("/logout");
         final MockHttpSession session = doBackChannelLogout();
         assertFalse(handler.process(request, response));

--- a/cas-client-core/src/test/java/org/jasig/cas/client/session/SingleSignOutHandlerTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/session/SingleSignOutHandlerTests.java
@@ -122,7 +122,7 @@ public final class SingleSignOutHandlerTests {
     }
 
     @Test
-    public void backChannelLogoutDoesDoesNotRunIfLogoutPathDoesNotMatch() {
+    public void backChannelLogoutDoesNotRunIfPathIsNotEligibleForLogout() {
         handler.setLogoutPath("/logout");
         request.setServletPath("/not-a-logout");
         final MockHttpSession session = doBackChannelLogout();
@@ -131,7 +131,7 @@ public final class SingleSignOutHandlerTests {
     }
 
     @Test
-    public void backChannelLogoutRunsWhenLogoutPathDoesMatch() {
+    public void backChannelLogoutRunsIfPathEqualsLogoutPath() {
         handler.setLogoutPath("/logout");
         request.setServletPath("/logout");
         final MockHttpSession session = doBackChannelLogout();

--- a/cas-client-integration-tomcat-v6/src/main/java/org/jasig/cas/client/tomcat/v6/SingleSignOutValve.java
+++ b/cas-client-integration-tomcat-v6/src/main/java/org/jasig/cas/client/tomcat/v6/SingleSignOutValve.java
@@ -60,6 +60,10 @@ public class SingleSignOutValve extends AbstractLifecycleValve implements Sessio
         this.handler.setCasServerUrlPrefix(casServerUrlPrefix);
     }
 
+    public void setLogoutPath(String logoutPath) {
+        this.handler.setLogoutPath(logoutPath);
+    }
+
     public void setSessionMappingStorage(final SessionMappingStorage storage) {
         this.handler.setSessionMappingStorage(storage);
     }

--- a/cas-client-integration-tomcat-v6/src/main/java/org/jasig/cas/client/tomcat/v6/SingleSignOutValve.java
+++ b/cas-client-integration-tomcat-v6/src/main/java/org/jasig/cas/client/tomcat/v6/SingleSignOutValve.java
@@ -60,8 +60,8 @@ public class SingleSignOutValve extends AbstractLifecycleValve implements Sessio
         this.handler.setCasServerUrlPrefix(casServerUrlPrefix);
     }
 
-    public void setLogoutPath(String logoutPath) {
-        this.handler.setLogoutPath(logoutPath);
+    public void setLogoutCallbackPath(String logoutCallbackPath) {
+        this.handler.setLogoutCallbackPath(logoutCallbackPath);
     }
 
     public void setSessionMappingStorage(final SessionMappingStorage storage) {

--- a/cas-client-integration-tomcat-v7/src/main/java/org/jasig/cas/client/tomcat/v7/SingleSignOutValve.java
+++ b/cas-client-integration-tomcat-v7/src/main/java/org/jasig/cas/client/tomcat/v7/SingleSignOutValve.java
@@ -64,6 +64,10 @@ public class SingleSignOutValve extends ValveBase implements SessionListener {
         this.handler.setCasServerUrlPrefix(casServerUrlPrefix);
     }
 
+    public void setLogoutPath(String logoutPath) {
+        this.handler.setLogoutPath(logoutPath);
+    }
+
     public void setSessionMappingStorage(final SessionMappingStorage storage) {
         this.handler.setSessionMappingStorage(storage);
     }

--- a/cas-client-integration-tomcat-v7/src/main/java/org/jasig/cas/client/tomcat/v7/SingleSignOutValve.java
+++ b/cas-client-integration-tomcat-v7/src/main/java/org/jasig/cas/client/tomcat/v7/SingleSignOutValve.java
@@ -64,8 +64,8 @@ public class SingleSignOutValve extends ValveBase implements SessionListener {
         this.handler.setCasServerUrlPrefix(casServerUrlPrefix);
     }
 
-    public void setLogoutPath(String logoutPath) {
-        this.handler.setLogoutPath(logoutPath);
+    public void setLogoutCallbackPath(String logoutCallbackPath) {
+        this.handler.setLogoutCallbackPath(logoutCallbackPath);
     }
 
     public void setSessionMappingStorage(final SessionMappingStorage storage) {

--- a/cas-client-integration-tomcat-v8/src/main/java/org/jasig/cas/client/tomcat/v8/SingleSignOutValve.java
+++ b/cas-client-integration-tomcat-v8/src/main/java/org/jasig/cas/client/tomcat/v8/SingleSignOutValve.java
@@ -64,6 +64,10 @@ public class SingleSignOutValve extends ValveBase implements SessionListener {
         this.handler.setCasServerUrlPrefix(casServerUrlPrefix);
     }
 
+    public void setLogoutPath(String logoutPath) {
+        this.handler.setLogoutPath(logoutPath);
+    }
+
     public void setSessionMappingStorage(final SessionMappingStorage storage) {
         this.handler.setSessionMappingStorage(storage);
     }

--- a/cas-client-integration-tomcat-v8/src/main/java/org/jasig/cas/client/tomcat/v8/SingleSignOutValve.java
+++ b/cas-client-integration-tomcat-v8/src/main/java/org/jasig/cas/client/tomcat/v8/SingleSignOutValve.java
@@ -64,8 +64,8 @@ public class SingleSignOutValve extends ValveBase implements SessionListener {
         this.handler.setCasServerUrlPrefix(casServerUrlPrefix);
     }
 
-    public void setLogoutPath(String logoutPath) {
-        this.handler.setLogoutPath(logoutPath);
+    public void setLogoutCallbackPath(String logoutCallbackPath) {
+        this.handler.setLogoutCallbackPath(logoutCallbackPath);
     }
 
     public void setSessionMappingStorage(final SessionMappingStorage storage) {

--- a/cas-client-integration-tomcat-v85/src/main/java/org/jasig/cas/client/tomcat/v85/SingleSignOutValve.java
+++ b/cas-client-integration-tomcat-v85/src/main/java/org/jasig/cas/client/tomcat/v85/SingleSignOutValve.java
@@ -64,6 +64,10 @@ public class SingleSignOutValve extends ValveBase implements SessionListener {
         this.handler.setCasServerUrlPrefix(casServerUrlPrefix);
     }
 
+    public void setLogoutPath(String logoutPath) {
+        this.handler.setLogoutPath(logoutPath);
+    }
+
     public void setSessionMappingStorage(final SessionMappingStorage storage) {
         this.handler.setSessionMappingStorage(storage);
     }

--- a/cas-client-integration-tomcat-v85/src/main/java/org/jasig/cas/client/tomcat/v85/SingleSignOutValve.java
+++ b/cas-client-integration-tomcat-v85/src/main/java/org/jasig/cas/client/tomcat/v85/SingleSignOutValve.java
@@ -64,8 +64,8 @@ public class SingleSignOutValve extends ValveBase implements SessionListener {
         this.handler.setCasServerUrlPrefix(casServerUrlPrefix);
     }
 
-    public void setLogoutPath(String logoutPath) {
-        this.handler.setLogoutPath(logoutPath);
+    public void setLogoutCallbackPath(String logoutCallbackPath) {
+        this.handler.setLogoutCallbackPath(logoutCallbackPath);
     }
 
     public void setSessionMappingStorage(final SessionMappingStorage storage) {


### PR DESCRIPTION
If someone's app cannot handle the SingleSignOutFilter's consumption of entity streams
(via a `request.getParameter()` call) on all requests,
they can use this option in conjunction with setting up a service logout URL at the CAS server.
The filter will now only consume the stream on requests to this path.

Fixes https://github.com/apereo/java-cas-client/issues/210.