### PR TITLE
Prioritize X-Forwarded-Host when choosing the service parameter

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
@@ -237,11 +237,7 @@ public final class CommonUtils {
         final String xHost = request.getHeader("X-Forwarded-Host");
 
         final String comparisonHost;
-        if (xHost != null && host == "localhost") {
-            comparisonHost = xHost;
-        } else {
-            comparisonHost = host;
-        }
+        comparisonHost = (xHost != null) ? xHost : host;
 
         if (comparisonHost == null) {
             return serverName;


### PR DESCRIPTION
Use X-Forwarded-Host whenever it's available.