### PR TITLE
Extract inlined CAS attributes in protocol 3 Ticket Validator

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/validation/Cas30ServiceTicketValidator.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/validation/Cas30ServiceTicketValidator.java
@@ -20,6 +20,7 @@ package org.jasig.cas.client.validation;
 
 import org.jasig.cas.client.util.XmlUtils;
 import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -58,12 +59,13 @@ public class Cas30ServiceTicketValidator extends Cas20ServiceTicketValidator {
         NodeList attributeList = document.getElementsByTagName("cas:attribute");
 
         for (int i = 0; i < attributeList.getLength(); i++) {
-            final Node attribute = attributeList.item(i);
-            if (attribute.getAttributes().getLength() > 0) {
-                attributes.put(attribute.getAttributes().getNamedItem("name").getNodeValue(),
-                               attribute.getAttributes().getNamedItem("value").getNodeValue());
+            final Node casAttributeNode = attributeList.item(i);
+            final NamedNodeMap casAttributes = casAttributeNode.getAttributes();
+            if (casAttributes.getLength() > 0) {
+                attributes.put(casAttributes.getNamedItem("name").getNodeValue(),
+                               casAttributes.getNamedItem("value").getNodeValue());
             } else {
-                attributes.put(attribute.getLocalName(), attribute.getNodeValue());
+                attributes.put(casAttributeNode.getLocalName(), casAttributeNode.getNodeValue());
             }
         }
 


### PR DESCRIPTION
Overrides extractCustomAttributes() method in Cas30ServiceTicketValidator to be able to extract attributes from the CAS validation response that have been inlined. 

A use case would be a CAS Server acting as a SAML IdP may want to inline attributes in the response in order to use attribute names in Uri format that contain namespaces and cannot be passed as <cas:ATTRIBUTE_NAME>