### PR TITLE
Support the method parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ The `AuthenticationFilter` is what detects whether a user needs to be authentica
 | `ignoreUrlPatternType` | Defines the type of the pattern specified. Defaults to `REGEX`. Other types are `CONTAINS`, `EXACT`, `FULL_REGEX`. Can also accept a fully-qualified class name that implements `UrlPatternMatcherStrategy`. | No
 | `gatewayStorageClass` | The storage class used to record gateway requests | No
 | `authenticationRedirectStrategyClass` | The class name of the component to decide how to handle authn redirects to CAS | No
+| `method` | The method used by the CAS server to send the user back to the application. Defaults to `null` | No
 
 ##### Ignore Patterns
 
@@ -252,6 +253,7 @@ The SAML 1.1 `AuthenticationFilter` is what detects whether a user needs to be a
 | `artifactParameterName ` | specifies the name of the request parameter on where to find the artifact (i.e. `SAMLart`). | No
 | `serviceParameterName ` | specifies the name of the request parameter on where to find the service (i.e. `TARGET`) | No
 | `encodeServiceUrl ` | Whether the client should auto encode the service url. Defaults to `true` | No
+| `method` | The method used by the CAS server to send the user back to the application. Defaults to `null` | No
 
 <a name="rgjasigcasclientvalidationcas10ticketvalidationfilter"></a>
 #### org.jasig.cas.client.validation.Cas10TicketValidationFilter

--- a/cas-client-core/pom.xml
+++ b/cas-client-core/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.jasig.cas.client</groupId>
-        <version>3.5.2-SNAPSHOT</version>
+        <version>3.6.0-SNAPSHOT</version>
         <artifactId>cas-client</artifactId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/cas-client-core/src/main/java/org/jasig/cas/client/authentication/AuthenticationFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/authentication/AuthenticationFilter.java
@@ -46,6 +46,7 @@ import java.util.Map;
  * <li><code>casServerLoginUrl</code> - the url to log into CAS, i.e. https://cas.rutgers.edu/login</li>
  * <li><code>renew</code> - true/false on whether to use renew or not.</li>
  * <li><code>gateway</code> - true/false on whether to use gateway or not.</li>
+ * <li><code>method</code> - the method used by the CAS server to send the user back to the application (redirect or post).</li>
  * </ul>
  *
  * <p>Please see AbstractCasFilter for additional properties.</p>
@@ -69,6 +70,11 @@ public class AuthenticationFilter extends AbstractCasFilter {
      * Whether to send the gateway request or not.
      */
     private boolean gateway = false;
+
+    /**
+     * The method used by the CAS server to send the user back to the application.
+     */
+    private String method;
 
     private GatewayResolver gatewayStorage = new DefaultGatewayResolverImpl();
 
@@ -107,6 +113,7 @@ public class AuthenticationFilter extends AbstractCasFilter {
 
             setRenew(getBoolean(ConfigurationKeys.RENEW));
             setGateway(getBoolean(ConfigurationKeys.GATEWAY));
+            setMethod(getString(ConfigurationKeys.METHOD));
 
             final String ignorePattern = getString(ConfigurationKeys.IGNORE_PATTERN);
             final String ignoreUrlPatternType = getString(ConfigurationKeys.IGNORE_URL_PATTERN_TYPE);
@@ -195,7 +202,7 @@ public class AuthenticationFilter extends AbstractCasFilter {
         logger.debug("Constructed service url: {}", modifiedServiceUrl);
 
         final String urlToRedirectTo = CommonUtils.constructRedirectUrl(this.casServerLoginUrl,
-            getProtocol().getServiceParameterName(), modifiedServiceUrl, this.renew, this.gateway);
+            getProtocol().getServiceParameterName(), modifiedServiceUrl, this.renew, this.gateway, this.method);
 
         logger.debug("redirecting to \"{}\"", urlToRedirectTo);
         this.authenticationRedirectStrategy.redirect(request, response, urlToRedirectTo);
@@ -207,6 +214,10 @@ public class AuthenticationFilter extends AbstractCasFilter {
 
     public final void setGateway(final boolean gateway) {
         this.gateway = gateway;
+    }
+
+    public void setMethod(final String method) {
+        this.method = method;
     }
 
     public final void setCasServerUrlPrefix(final String casServerUrlPrefix) {

--- a/cas-client-core/src/main/java/org/jasig/cas/client/configuration/ConfigurationKeys.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/configuration/ConfigurationKeys.java
@@ -49,6 +49,7 @@ public interface ConfigurationKeys {
     ConfigurationKey<Boolean> IGNORE_CASE = new ConfigurationKey<Boolean>("ignoreCase", Boolean.FALSE);
     ConfigurationKey<String> CAS_SERVER_LOGIN_URL = new ConfigurationKey<String>("casServerLoginUrl", null);
     ConfigurationKey<Boolean> GATEWAY = new ConfigurationKey<Boolean>("gateway", Boolean.FALSE);
+    ConfigurationKey<String> METHOD = new ConfigurationKey<String>("method", null);
     ConfigurationKey<Class<? extends AuthenticationRedirectStrategy>> AUTHENTICATION_REDIRECT_STRATEGY_CLASS = new ConfigurationKey<Class<? extends AuthenticationRedirectStrategy>>("authenticationRedirectStrategyClass", null);
     ConfigurationKey<Class<? extends GatewayResolver>> GATEWAY_STORAGE_CLASS = new ConfigurationKey<Class<? extends GatewayResolver>>("gatewayStorageClass", DefaultGatewayResolverImpl.class);
     ConfigurationKey<String> CAS_SERVER_URL_PREFIX = new ConfigurationKey<String>("casServerUrlPrefix", null);

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/AbstractCasFilter.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/AbstractCasFilter.java
@@ -25,6 +25,7 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
 
 /**
  *  Abstract filter that contains code that is common to all CAS filters.
@@ -140,6 +141,7 @@ public abstract class AbstractCasFilter extends AbstractConfigurationFilter {
      * @return the ticket if its found, null otherwise.
      */
     protected String retrieveTicketFromRequest(final HttpServletRequest request) {
-        return CommonUtils.safeGetParameter(request, this.protocol.getArtifactParameterName());
+        return CommonUtils.safeGetParameter(request, this.protocol.getArtifactParameterName(),
+                Arrays.asList(this.protocol.getArtifactParameterName()));
     }
 }

--- a/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/util/CommonUtils.java
@@ -179,12 +179,14 @@ public final class CommonUtils {
      * @param serviceUrl the actual service's url.
      * @param renew whether we should send renew or not.
      * @param gateway where we should send gateway or not.
+     * @param method the method used by the CAS server to send the user back to the application.
      * @return the fully constructed redirect url.
      */
     public static String constructRedirectUrl(final String casServerLoginUrl, final String serviceParameterName,
-            final String serviceUrl, final boolean renew, final boolean gateway) {
+            final String serviceUrl, final boolean renew, final boolean gateway, final String method) {
         return casServerLoginUrl + (casServerLoginUrl.contains("?") ? "&" : "?") + serviceParameterName + "="
-                + urlEncode(serviceUrl) + (renew ? "&renew=true" : "") + (gateway ? "&gateway=true" : "");
+                + urlEncode(serviceUrl) + (renew ? "&renew=true" : "") + (gateway ? "&gateway=true" : "")
+                + (method != null ? "&method=" + method : "");
     }
 
     /**

--- a/cas-client-core/src/test/java/org/jasig/cas/client/util/CommonUtilsTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/util/CommonUtilsTests.java
@@ -41,7 +41,9 @@ public final class CommonUtilsTests extends TestCase {
 
     public void testRedirectUrlWithParam() {
         final String loginUrl = "http://localhost:8080/login?myName=foo";
-        final String fullyConstructedUrl = CommonUtils.constructRedirectUrl(loginUrl, "foo", "foo", false, false);
+        final String fullyConstructedUrl = CommonUtils.constructRedirectUrl(loginUrl, "foo", "foo", false, false, null);
+
+        assertEquals("http://localhost:8080/login?myName=foo&foo=foo", fullyConstructedUrl);
 
         int count = 0;
         final char[] chars = fullyConstructedUrl.toCharArray();
@@ -53,6 +55,13 @@ public final class CommonUtilsTests extends TestCase {
         }
 
         assertEquals(1, count);
+    }
+
+    public void testRedirectUrlWithMethod() {
+        final String loginUrl = "http://localhost:8080/login";
+        final String redirectUrl = CommonUtils.constructRedirectUrl(loginUrl, "foo", "foo", true, true, "post");
+
+        assertEquals("http://localhost:8080/login?foo=foo&renew=true&gateway=true&method=post", redirectUrl);
     }
 
     public void testAssertNotNull() {

--- a/cas-client-integration-atlassian/pom.xml
+++ b/cas-client-integration-atlassian/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.jasig.cas.client</groupId>
-        <version>3.5.2-SNAPSHOT</version>
+        <version>3.6.0-SNAPSHOT</version>
         <artifactId>cas-client</artifactId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/cas-client-integration-jboss/pom.xml
+++ b/cas-client-integration-jboss/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.jasig.cas.client</groupId>
-        <version>3.5.2-SNAPSHOT</version>
+        <version>3.6.0-SNAPSHOT</version>
         <artifactId>cas-client</artifactId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/cas-client-integration-jetty/pom.xml
+++ b/cas-client-integration-jetty/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cas-client</artifactId>
         <groupId>org.jasig.cas.client</groupId>
-        <version>3.5.2-SNAPSHOT</version>
+        <version>3.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cas-client-integration-jetty/src/main/java/org/jasig/cas/client/jetty/CasAuthenticator.java
+++ b/cas-client-integration-jetty/src/main/java/org/jasig/cas/client/jetty/CasAuthenticator.java
@@ -237,7 +237,7 @@ public class CasAuthenticator extends AbstractLifeCycle implements Authenticator
             final HttpServletRequest request, final HttpServletResponse response) throws ServerAuthException {
         try {
             final String redirectUrl = CommonUtils.constructRedirectUrl(
-                    casServerLoginUrl, protocol.getServiceParameterName(), serviceUrl(request, response), renew, false);
+                    casServerLoginUrl, protocol.getServiceParameterName(), serviceUrl(request, response), renew, false, null);
             logger.debug("Redirecting to {}", redirectUrl);
             response.sendRedirect(redirectUrl);
         } catch (IOException e) {

--- a/cas-client-integration-tomcat-common/pom.xml
+++ b/cas-client-integration-tomcat-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cas-client</artifactId>
         <groupId>org.jasig.cas.client</groupId>
-        <version>3.5.2-SNAPSHOT</version>
+        <version>3.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cas-client-integration-tomcat-common/src/main/java/org/jasig/cas/client/tomcat/AuthenticatorDelegate.java
+++ b/cas-client-integration-tomcat-common/src/main/java/org/jasig/cas/client/tomcat/AuthenticatorDelegate.java
@@ -89,7 +89,7 @@ public final class AuthenticatorDelegate {
                     this.serviceParameterName, this.artifactParameterName, true);
             if (CommonUtils.isBlank(token)) {
                 final String redirectUrl = CommonUtils.constructRedirectUrl(this.casServerLoginUrl,
-                        this.serviceParameterName, service, false, false);
+                        this.serviceParameterName, service, false, false, null);
                 logger.debug("Redirecting to {}", redirectUrl);
                 CommonUtils.sendRedirect(response, redirectUrl);
                 return null;

--- a/cas-client-integration-tomcat-v6/pom.xml
+++ b/cas-client-integration-tomcat-v6/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cas-client</artifactId>
         <groupId>org.jasig.cas.client</groupId>
-        <version>3.5.2-SNAPSHOT</version>
+        <version>3.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cas-client-integration-tomcat-v7/pom.xml
+++ b/cas-client-integration-tomcat-v7/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cas-client</artifactId>
         <groupId>org.jasig.cas.client</groupId>
-        <version>3.5.2-SNAPSHOT</version>
+        <version>3.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cas-client-integration-tomcat-v8/pom.xml
+++ b/cas-client-integration-tomcat-v8/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cas-client</artifactId>
         <groupId>org.jasig.cas.client</groupId>
-        <version>3.5.2-SNAPSHOT</version>
+        <version>3.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cas-client-integration-tomcat-v85/pom.xml
+++ b/cas-client-integration-tomcat-v85/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cas-client</artifactId>
         <groupId>org.jasig.cas.client</groupId>
-        <version>3.5.2-SNAPSHOT</version>
+        <version>3.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cas-client-support-distributed-ehcache/pom.xml
+++ b/cas-client-support-distributed-ehcache/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cas-client</artifactId>
         <groupId>org.jasig.cas.client</groupId>
-        <version>3.5.2-SNAPSHOT</version>
+        <version>3.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Jasig CAS Client for Java - Distributed Proxy Storage Support: EhCache

--- a/cas-client-support-distributed-memcached/pom.xml
+++ b/cas-client-support-distributed-memcached/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cas-client</artifactId>
         <groupId>org.jasig.cas.client</groupId>
-        <version>3.5.2-SNAPSHOT</version>
+        <version>3.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cas-client-support-saml/pom.xml
+++ b/cas-client-support-saml/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>org.jasig.cas.client</groupId>
-        <version>3.5.2-SNAPSHOT</version>
+        <version>3.6.0-SNAPSHOT</version>
         <artifactId>cas-client</artifactId>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jasig.cas.client</groupId>
-    <version>3.5.2-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
     <artifactId>cas-client</artifactId>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
I recently realized that the `method` parameter supported in the CAS server was not available at the client level.
It will be fixed in pac4j-cas v3.7.0 and I'm proposing to fix that in a new version 3.6.0 of the Java CAS client. Maybe we should create a 3.5.x branch?

The change is fairly easy with a test to confirm the behavior.

In fact, there was also a bug in the `retrieveTicketFromRequest` method which was not able to retrieve the ticket parameter from a POST request. It's fixed by adding the ticket as a safe parameter.
