### PR TITLE
Make Cas20ServiceTicketValidator method populateUrlAttributeMap not final

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/validation/Cas20ServiceTicketValidator.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/validation/Cas20ServiceTicketValidator.java
@@ -20,7 +20,12 @@ package org.jasig.cas.client.validation;
 
 import java.io.StringReader;
 import java.security.PrivateKey;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 import javax.crypto.Cipher;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -79,7 +84,7 @@ public class Cas20ServiceTicketValidator extends AbstractCasProtocolUrlBasedTick
      * @param urlParameters the Map containing the existing parameters to send to the server.
      */
     @Override
-    protected final void populateUrlAttributeMap(final Map<String, String> urlParameters) {
+    protected void populateUrlAttributeMap(final Map<String, String> urlParameters) {
         urlParameters.put("pgtUrl", this.proxyCallbackUrl);
     }
 

--- a/cas-client-core/src/main/java/org/jasig/cas/client/validation/Cas20ServiceTicketValidator.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/validation/Cas20ServiceTicketValidator.java
@@ -20,11 +20,7 @@ package org.jasig.cas.client.validation;
 
 import java.io.StringReader;
 import java.security.PrivateKey;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import javax.crypto.Cipher;
 import javax.xml.parsers.SAXParser;


### PR DESCRIPTION
When we validate the ticket, we want to check whether the url is valid, so we want to add some attributes in the validate url, but the populateUrlAttributeMap method is made final in Cas20ServiceTicketValidator, that makes it hard to extend this feature. So I make that method not final, and make it possible to do this extension, please check.