### PR TITLE
Add dependency jaxb-api for building with jdk 11+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,22 @@
         <url>https://www.apereo.org</url>
     </organization>
 
+    <profiles>
+        <profile>
+            <id>jdk11+</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                    <version>2.3.1</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
JAXB has been removed from JDK 11. It would add dependency jaxb-api for JDK 11 and later.