### PR TITLE
Fixing memory leak, full description:

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/HashMapBackedSessionMappingStorage.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/HashMapBackedSessionMappingStorage.java
@@ -80,4 +80,14 @@ public final class HashMapBackedSessionMappingStorage implements SessionMappingS
 
         return session;
     }
+
+    @Override
+    public synchronized void changeSessionId(String oldSessionId, String newSessionId) {
+        logger.debug("Fixing session id mapping, old id: {}, new id: {}", oldSessionId, newSessionId);
+
+        String removedValue = ID_TO_SESSION_KEY_MAPPING.remove(oldSessionId);
+        if (removedValue != null) {
+            ID_TO_SESSION_KEY_MAPPING.put(newSessionId, removedValue);
+        }
+    }
 }

--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/SessionMappingStorage.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/SessionMappingStorage.java
@@ -51,4 +51,10 @@ public interface SessionMappingStorage {
      */
     void addSessionById(String mappingId, HttpSession session);
 
+    /**
+     * Fixing mapping after session id change.
+     * @param newSessionId session id after change
+     * @param oldSessionId session id before change
+     */
+    void changeSessionId(String oldSessionId, String newSessionId);
 }

--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHttpSessionListener.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHttpSessionListener.java
@@ -20,6 +20,7 @@ package org.jasig.cas.client.session;
 
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionIdListener;
 import javax.servlet.http.HttpSessionListener;
 
 /**
@@ -32,7 +33,7 @@ import javax.servlet.http.HttpSessionListener;
  * @version $Revision$ Date$
  * @since 3.1
  */
-public final class SingleSignOutHttpSessionListener implements HttpSessionListener {
+public final class SingleSignOutHttpSessionListener implements HttpSessionListener, HttpSessionIdListener {
 
     private SessionMappingStorage sessionMappingStorage;
 
@@ -48,6 +49,15 @@ public final class SingleSignOutHttpSessionListener implements HttpSessionListen
         }
         final HttpSession session = event.getSession();
         sessionMappingStorage.removeBySessionById(session.getId());
+    }
+
+    @Override
+    public void sessionIdChanged(HttpSessionEvent event, String oldSessionId) {
+        if (sessionMappingStorage == null) {
+            sessionMappingStorage = getSessionMappingStorage();
+        }
+        final HttpSession session = event.getSession();
+        sessionMappingStorage.changeSessionId(oldSessionId, session.getId());
     }
 
     /**


### PR DESCRIPTION
The class org.jasig.cas.client.session.HashMapBackedSessionMappingStorage contains 2 maps:

private final Map<String, HttpSession> MANAGED_SESSIONS = new HashMap<String, HttpSession>();
private final Map<String, String> ID_TO_SESSION_KEY_MAPPING = new HashMap<String, String>();

There is a part of CAS client, that listens on server events and clears that storage on session destroy. That code is in org.jasig.cas.client.session.SingleSignOutHttpSessionListener. The problem is that the public API of the javax.servlet.http.HttpServletRequest has a method (from servlet v3.1):
String changeSessionId();
That method doesn't destroy a session, but changes its id. This type of action doesn't affect the maps in the HashMapBackedSessionMappingStorage. It causes memory leak, because session with changed id cannot be removed from the storage. Changing session id is the default of Spring implementation of session fixation, so the problem may be popular in the future. The default is implemented in org.springframework.security.web.authentication.session.ChangeSessionIdAuthenticationStrategy and is created as default in org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer#createDefaultSessionFixationProtectionStrategy.

Possible fix: implement listener that implements javax.servlet.http.HttpSessionIdListener that manipulates the maps in HashMapBackedSessionMappingStorage.