### PR TITLE
log4j dependency cleanup

### DIFF
--- a/cas-client-core/pom.xml
+++ b/cas-client-core/pom.xml
@@ -95,7 +95,6 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <scope>test</scope>
-            <version>1.2.17</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jmxri</artifactId>

--- a/cas-client-core/pom.xml
+++ b/cas-client-core/pom.xml
@@ -95,20 +95,6 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>jmxri</artifactId>
-                    <groupId>com.sun.jmx</groupId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jdmk</groupId>
-                    <artifactId>jmxtools</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.jms</groupId>
-                    <artifactId>jms</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -223,20 +223,6 @@
                 <artifactId>log4j</artifactId>
                 <scope>test</scope>
                 <version>1.2.17</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>jmxri</artifactId>
-                        <groupId>com.sun.jmx</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sun.jdmk</groupId>
-                        <artifactId>jmxtools</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.jms</groupId>
-                        <artifactId>jms</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Hello,

I made 2 changes with some corrections for log4j dependency in the project:
* _client-core: don't override log4j version_ - you/we want to use one version of this dependency in all subproject. In log4j is used in several places, but only in _client-core_ the version is overwritten (on the same version)
* _Unnecessary exclusions of log4j_ - some time ago log4j dependency was updated, but exlusions were left the same. Current version of log4j doesn't need those exclusions.

(This is kind of a test for some other changes I'd like to do in the project. I'd like to get to know 'project flow' here :-))