### PR TITLE
Remove all JUnit deprecation warnings

### DIFF
--- a/cas-client-core/src/test/java/org/jasig/cas/client/SerializationTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/SerializationTests.java
@@ -23,13 +23,13 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Collections;
-import junit.framework.Assert;
 import junit.framework.TestCase;
 import org.jasig.cas.client.authentication.AttributePrincipalImpl;
 import org.jasig.cas.client.authentication.SimpleGroup;
 import org.jasig.cas.client.authentication.SimplePrincipal;
 import org.jasig.cas.client.jaas.AssertionPrincipal;
 import org.jasig.cas.client.validation.AssertionImpl;
+import org.junit.Assert;
 
 /**
  * Confirms serialization support for classes intended for session storage or

--- a/cas-client-core/src/test/java/org/jasig/cas/client/ssl/RegexHostnameVerifierTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/ssl/RegexHostnameVerifierTests.java
@@ -31,7 +31,7 @@
 */
 package org.jasig.cas.client.ssl;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 
 /**

--- a/cas-client-core/src/test/java/org/jasig/cas/client/ssl/WhitelistHostnameVerifierTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/ssl/WhitelistHostnameVerifierTests.java
@@ -31,7 +31,7 @@
 */
 package org.jasig.cas.client.ssl;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.TestCase;
 
 /**

--- a/cas-client-core/src/test/java/org/jasig/cas/client/validation/json/Cas30JsonServiceTicketValidatorTests.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/validation/json/Cas30JsonServiceTicketValidatorTests.java
@@ -27,7 +27,7 @@ import org.jasig.cas.client.validation.Assertion;
 import org.jasig.cas.client.validation.TicketValidationException;
 import org.junit.Before;
 import org.junit.Test;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 public class Cas30JsonServiceTicketValidatorTests extends AbstractTicketValidatorTests {
     private static final PublicTestHttpServer server = PublicTestHttpServer.instance(8088);


### PR DESCRIPTION
Change of import, `junit.framework -> org.junit`, is enough to get rid of warnings.