### PR TITLE
Improved SamlUtilsTests

### DIFF
--- a/cas-client-support-saml/src/test/java/org/jasig/cas/client/util/SamlUtilsTests.java
+++ b/cas-client-support-saml/src/test/java/org/jasig/cas/client/util/SamlUtilsTests.java
@@ -20,20 +20,22 @@ package org.jasig.cas.client.util;
 
 import java.util.Date;
 
+import org.junit.Assert;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 /**
  * Test cases for {@link SamlUtils}.
  *
  * @author Marvin S. Addison
+ * @author Emil Sierżęga
  */
-public class SamlUtilsTest {
+public class SamlUtilsTests {
 
     @Test
     public void testParseUtcDate() {
         final Date expected = new Date(1424437961025L);
-        assertEquals(expected, SamlUtils.parseUtcDate("2015-02-20T08:12:41.025-0500"));
+        Assert.assertEquals(expected, SamlUtils.parseUtcDate("2015-02-20T08:12:41.025-0500"));
+        final Date expectedNoMillis = new Date(1424437961000L);
+        Assert.assertEquals(expectedNoMillis, SamlUtils.parseUtcDate("2015-02-20T08:12:41-0500"));
     }
 }


### PR DESCRIPTION
* SamlUtilsTest -> SamlUtilsTests (autorun on mvn build... since the name wasn't fit to surefire convention the test was disabled)
* Add sample for parsing date without milliseconds
* Removed import static (can argue with that, but I can see that most of tests uses normal import)