### PR TITLE
Use Java Platform for Base64

### DIFF
--- a/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHandler.java
+++ b/cas-client-core/src/main/java/org/jasig/cas/client/session/SingleSignOutHandler.java
@@ -19,6 +19,7 @@
 package org.jasig.cas.client.session;
 
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.zip.Inflater;
@@ -27,7 +28,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import javax.xml.bind.DatatypeConverter;
 
 import org.jasig.cas.client.Protocol;
 import org.jasig.cas.client.configuration.ConfigurationKeys;
@@ -232,7 +232,7 @@ public final class SingleSignOutHandler {
      * @return the uncompressed logout message.
      */
     private String uncompressLogoutMessage(final String originalMessage) {
-        final byte[] binaryMessage = DatatypeConverter.parseBase64Binary(originalMessage);
+        final byte[] binaryMessage = Base64.getDecoder().decode(originalMessage);
 
         Inflater decompresser = null;
         try {

--- a/cas-client-core/src/test/java/org/jasig/cas/client/session/LogoutMessageGenerator.java
+++ b/cas-client-core/src/test/java/org/jasig/cas/client/session/LogoutMessageGenerator.java
@@ -18,8 +18,8 @@
  */
 package org.jasig.cas.client.session;
 
-import javax.xml.bind.DatatypeConverter;
 import java.nio.charset.Charset;
+import java.util.Base64;
 import java.util.Date;
 import java.util.zip.Deflater;
 
@@ -50,6 +50,6 @@ public final class LogoutMessageGenerator {
         final int resultSize = deflater.deflate(buffer);
         final byte[] output = new byte[resultSize];
         System.arraycopy(buffer, 0, output, 0, resultSize);
-        return DatatypeConverter.printBase64Binary(output);
+        return Base64.getEncoder().encodeToString(output);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -264,16 +264,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-core</artifactId>
-            <version>3.0.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <version>${slf4j.version}</version>


### PR DESCRIPTION
This repository currently uses JAXB for Bsae64 encoding and decoding. This third-party dependency is unnecessary, as the Java Platform provides a native API for Base64 encoding and decoding. In this PR we switch to the native Java Platform functionality and eliminate an unnecessary dependency. This eases maintenance by eliminating the need to update that dependency.