### PR TITLE
Migrate away from Joda Time to use JSR-310 Java Time

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -74,7 +74,6 @@ This project includes:
   Jetty :: Utilities :: Ajax(JSON) under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty :: Webapp Application Support under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty :: XML utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
-  Joda-Time under Apache License, Version 2.0
   JUL to SLF4J bridge under MIT License
   JUnit under Eclipse Public License 1.0
   Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License

--- a/cas-client-integration-tomcat-v6/NOTICE
+++ b/cas-client-integration-tomcat-v6/NOTICE
@@ -36,7 +36,6 @@ This project includes:
   JAXB Core under CDDL+GPL License
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
-  Joda-Time under Apache License, Version 2.0
   JUnit under Eclipse Public License 1.0
   SLF4J API Module under MIT License
   SLF4J Simple Binding under MIT License

--- a/cas-client-integration-tomcat-v7/NOTICE
+++ b/cas-client-integration-tomcat-v7/NOTICE
@@ -34,7 +34,6 @@ This project includes:
   JAXB Core under CDDL+GPL License
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
-  Joda-Time under Apache License, Version 2.0
   JUnit under Eclipse Public License 1.0
   SLF4J API Module under MIT License
   SLF4J Simple Binding under MIT License

--- a/cas-client-integration-tomcat-v8/NOTICE
+++ b/cas-client-integration-tomcat-v8/NOTICE
@@ -34,7 +34,6 @@ This project includes:
   JAXB Core under CDDL+GPL License
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
-  Joda-Time under Apache License, Version 2.0
   JUnit under Eclipse Public License 1.0
   SLF4J API Module under MIT License
   SLF4J Simple Binding under MIT License

--- a/cas-client-integration-tomcat-v85/NOTICE
+++ b/cas-client-integration-tomcat-v85/NOTICE
@@ -34,7 +34,6 @@ This project includes:
   JAXB Core under CDDL+GPL License
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
-  Joda-Time under Apache License, Version 2.0
   JUnit under Eclipse Public License 1.0
   SLF4J API Module under MIT License
   SLF4J Simple Binding under MIT License

--- a/cas-client-integration-tomcat-v90/NOTICE
+++ b/cas-client-integration-tomcat-v90/NOTICE
@@ -34,7 +34,6 @@ This project includes:
   JAXB Core under CDDL+GPL License
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
-  Joda-Time under Apache License, Version 2.0
   JUnit under Eclipse Public License 1.0
   SLF4J API Module under MIT License
   SLF4J Simple Binding under MIT License

--- a/cas-client-support-saml/NOTICE
+++ b/cas-client-support-saml/NOTICE
@@ -32,7 +32,6 @@ This project includes:
   JAXB Core under CDDL+GPL License
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
-  Joda-Time under Apache License, Version 2.0
   JUnit under Eclipse Public License 1.0
   SLF4J API Module under MIT License
   SLF4J Simple Binding under MIT License

--- a/cas-client-support-saml/pom.xml
+++ b/cas-client-support-saml/pom.xml
@@ -35,11 +35,6 @@
             <artifactId>cas-client-core</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.10.14</version>
-        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/cas-client-support-saml/src/main/java/org/jasig/cas/client/util/SamlUtils.java
+++ b/cas-client-support-saml/src/main/java/org/jasig/cas/client/util/SamlUtils.java
@@ -18,12 +18,11 @@
  */
 package org.jasig.cas.client.util;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.Date;
-
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 
 /**
  * SAML utility class.
@@ -33,20 +32,32 @@ import org.joda.time.format.ISODateTimeFormat;
  */
 public final class SamlUtils {
 
-    private static final DateTimeFormatter ISO_FORMAT = ISODateTimeFormat.dateTimeNoMillis();
+    private static final DateTimeFormatter ISO_FORMATTER_NO_MILLIS = new DateTimeFormatterBuilder()
+            .append(DateTimeFormatter.ofPattern("YYYY-MM-dd'T'HH:mm:ss"))
+            .parseLenient()
+            .appendOffset("+HHMM", "Z")
+            .parseStrict()
+            .toFormatter();
+    private static final DateTimeFormatter ISO_PARSER_WITH_MILLIS = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            .parseLenient()
+            .appendOffset("+HHMM", "Z")
+            .parseStrict()
+            .toFormatter();
 
     private SamlUtils() {
         // nothing to do
     }
 
     public static String formatForUtcTime(final Date date) {
-        return ISO_FORMAT.print(new DateTime(date).withZone(DateTimeZone.UTC));
+        return ISO_FORMATTER_NO_MILLIS.format(ZonedDateTime.ofInstant(date.toInstant(), ZoneOffset.UTC));
     }
 
     public static Date parseUtcDate(final String date) {
         if (CommonUtils.isEmpty(date)) {
             return null;
         }
-        return ISODateTimeFormat.dateTimeParser().parseDateTime(date).toDate();
+        return Date.from(ZonedDateTime.parse(date, ISO_PARSER_WITH_MILLIS).toInstant());
     }
 }

--- a/cas-client-support-saml/src/test/java/org/jasig/cas/client/util/SamlUtilsTests.java
+++ b/cas-client-support-saml/src/test/java/org/jasig/cas/client/util/SamlUtilsTests.java
@@ -18,10 +18,11 @@
  */
 package org.jasig.cas.client.util;
 
-import java.util.Date;
-
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.Date;
 
 /**
  * Test cases for {@link SamlUtils}.
@@ -37,5 +38,17 @@ public class SamlUtilsTests {
         Assert.assertEquals(expected, SamlUtils.parseUtcDate("2015-02-20T08:12:41.025-0500"));
         final Date expectedNoMillis = new Date(1424437961000L);
         Assert.assertEquals(expectedNoMillis, SamlUtils.parseUtcDate("2015-02-20T08:12:41-0500"));
+    }
+
+    @Test
+    public void testFormatUtcDate() {
+        final Calendar calendar = Calendar.getInstance();
+        final String expected = "2015-02-20T13:12:41Z";
+
+        calendar.setTimeInMillis(1424437961025L);
+        Assert.assertEquals(expected, SamlUtils.formatForUtcTime(calendar.getTime()));
+
+        calendar.setTimeInMillis(1424437961000L);
+        Assert.assertEquals(expected, SamlUtils.formatForUtcTime(calendar.getTime()));
     }
 }

--- a/cas-client-support-saml/src/test/java/org/jasig/cas/client/validation/Saml11TicketValidatorTests.java
+++ b/cas-client-support-saml/src/test/java/org/jasig/cas/client/validation/Saml11TicketValidatorTests.java
@@ -21,16 +21,14 @@ package org.jasig.cas.client.validation;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import java.io.UnsupportedEncodingException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Date;
 import org.jasig.cas.client.PublicTestHttpServer;
 import org.jasig.cas.client.util.SamlUtils;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.Interval;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
 
 /**
  * @author Scott Battaglia
@@ -80,16 +78,17 @@ public final class Saml11TicketValidatorTests extends AbstractTicketValidatorTes
 
     @Test
     public void testCompatibilityValidationSuccessWithNoAttributes() throws UnsupportedEncodingException {
-        final Interval range = currentTimeRangeInterval();
+        final ZonedDateTime startTime = currentTimeRangeStart();
+        final ZonedDateTime endTime = currentTimeRangeEnd();
         final Date now = new Date();
         final String RESPONSE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"><SOAP-ENV:Header/><SOAP-ENV:Body><Response xmlns=\"urn:oasis:names:tc:SAML:1.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:1.0:assertion\" xmlns:samlp=\"urn:oasis:names:tc:SAML:1.0:protocol\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" IssueInstant=\""
                 + SamlUtils.formatForUtcTime(now)
                 + "\" MajorVersion=\"1\" MinorVersion=\"1\" Recipient=\"test\" ResponseID=\"_e1e2124c08ab456eab0bbab3e1c0c433\"><Status><StatusCode Value=\"samlp:Success\"></StatusCode></Status><Assertion xmlns=\"urn:oasis:names:tc:SAML:1.0:assertion\" AssertionID=\"_d2fd0d6e4da6a6d7d2ba5274ab570d5c\" IssueInstant=\""
                 + SamlUtils.formatForUtcTime(now)
                 + "\" Issuer=\"testIssuer\" MajorVersion=\"1\" MinorVersion=\"1\"><Conditions NotBefore=\""
-                + SamlUtils.formatForUtcTime(range.getStart().toDate())
+                + SamlUtils.formatForUtcTime(Date.from(startTime.toInstant()))
                 + "\" NotOnOrAfter=\""
-                + SamlUtils.formatForUtcTime(range.getEnd().toDate())
+                + SamlUtils.formatForUtcTime(Date.from(endTime.toInstant()))
                 + "\"><AudienceRestrictionCondition><Audience>test</Audience></AudienceRestrictionCondition></Conditions><AuthenticationStatement AuthenticationInstant=\"2008-06-19T14:34:44.426Z\" AuthenticationMethod=\"urn:ietf:rfc:2246\"><Subject><NameIdentifier>testPrincipal</NameIdentifier><SubjectConfirmation><ConfirmationMethod>urn:oasis:names:tc:SAML:1.0:cm:artifact</ConfirmationMethod></SubjectConfirmation></Subject></AuthenticationStatement></Assertion></Response></SOAP-ENV:Body></SOAP-ENV:Envelope>";
         server.content = RESPONSE.getBytes(server.encoding);
         try {
@@ -102,7 +101,8 @@ public final class Saml11TicketValidatorTests extends AbstractTicketValidatorTes
 
     @Test
     public void openSaml2GeneratedResponse() throws UnsupportedEncodingException {
-        final Interval range = currentTimeRangeInterval();
+        final ZonedDateTime startTime = currentTimeRangeStart();
+        final ZonedDateTime endTime = currentTimeRangeEnd();
         final Date now = new Date();
 
         final String response = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soap11:Envelope xmlns:soap11=\"http://schemas.xmlsoap.org/soap/envelope/\"><soap11:Body>"
@@ -114,9 +114,9 @@ public final class Saml11TicketValidatorTests extends AbstractTicketValidatorTes
                 + SamlUtils.formatForUtcTime(now)
                 + "\" Issuer=\"localhost\" MajorVersion=\"1\" MinorVersion=\"1\">"
                 + "<saml1:Conditions NotBefore=\""
-                + SamlUtils.formatForUtcTime(range.getStart().toDate())
+                + SamlUtils.formatForUtcTime(Date.from(startTime.toInstant()))
                 + "\" NotOnOrAfter=\""
-                + SamlUtils.formatForUtcTime(range.getEnd().toDate())
+                + SamlUtils.formatForUtcTime(Date.from(endTime.toInstant()))
                 + "\">"
                 + "<saml1:AudienceRestrictionCondition><saml1:Audience>https://example.com/test-client/secure/</saml1:Audience>"
                 + "</saml1:AudienceRestrictionCondition></saml1:Conditions>"
@@ -151,7 +151,11 @@ public final class Saml11TicketValidatorTests extends AbstractTicketValidatorTes
         }
     }
 
-    private Interval currentTimeRangeInterval() {
-        return new Interval(new DateTime(DateTimeZone.UTC).minus(5000), new DateTime(DateTimeZone.UTC).plus(200000000));
+    private ZonedDateTime currentTimeRangeStart() {
+        return ZonedDateTime.now(ZoneOffset.UTC).minus(5000, ChronoUnit.MILLIS);
+    }
+
+    private ZonedDateTime currentTimeRangeEnd() {
+        return ZonedDateTime.now(ZoneOffset.UTC).plus(200000000, ChronoUnit.MILLIS);
     }
 }

--- a/cas-client-support-springboot/NOTICE
+++ b/cas-client-support-springboot/NOTICE
@@ -37,7 +37,6 @@ This project includes:
   JAXB Core under CDDL+GPL License
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
   JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
-  Joda-Time under Apache License, Version 2.0
   JUL to SLF4J bridge under MIT License
   JUnit under Eclipse Public License 1.0
   Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License


### PR DESCRIPTION
Joda Time is not really a necessary dependency in the world of Java 8 and JSR-310 - Even the developer of Joda Time acknowledges that (see https://blog.joda.org/2014/11/converting-from-joda-time-to-javatime.html)

The use of Joda Time in this project is quite limited - none of your public APIs take or return Joda Time types, they are only used internally as a better way to do date formatting and comparisons.

However, due to transitive dependencies, anyone who uses your project as a library is automatically exposed to the Joda Time classes, and may start using them without really thinking through the decision.  This is the situation that triggered my interest - a project I'm working on depends on a library that in turn depends on this, and I unexpectedly found Joda Time classes in my classpath.

I'd therefore like to offer this PR as a proof-of-concept that removing Joda Time is reasonably practical, and I would request that you review it, and consider either merging it, or implementing the suggested changes yourselves (perhaps using OffsetDateTime rather than ZonedDateTime, if you prefer).