### PR TITLE
fix(sec): upgrade xml-security:xmlsec to 1.5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
         <javax.servlet.version>6.0.0</javax.servlet.version>
         <commons.codec.version>1.15</commons.codec.version>
         <log4j.version>1.2.17</log4j.version>
-        <xmlsec.version>1.3.0</xmlsec.version>
+        <xmlsec.version>1.5.6</xmlsec.version>
         <bouncycastle.version>1.70</bouncycastle.version>
         <springboot.version>3.0.0-M5</springboot.version>
         <spring.security.version>6.0.0-M7</spring.security.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in xml-security:xmlsec 1.3.0
- [CVE-2013-4517](https://www.oscs1024.com/hd/CVE-2013-4517)


### What did I do？
Upgrade xml-security:xmlsec from 1.3.0 to 1.5.6 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS