### PR TITLE
feat: Remove "renew" block

### DIFF
--- a/cas-client-core/src/main/java/org/apereo/cas/client/configuration/WebXmlConfigurationStrategyImpl.java
+++ b/cas-client-core/src/main/java/org/apereo/cas/client/configuration/WebXmlConfigurationStrategyImpl.java
@@ -44,7 +44,6 @@ public final class WebXmlConfigurationStrategyImpl extends BaseConfigurationStra
         final String value = this.filterConfig.getInitParameter(configurationKey.getName());
 
         if (CommonUtils.isNotBlank(value)) {
-            CommonUtils.assertFalse(ConfigurationKeys.RENEW.equals(configurationKey), "Renew MUST be specified via context parameter or JNDI environment to avoid misconfiguration.");
             logger.info("Property [{}] loaded from FilterConfig.getInitParameter with value [{}]", configurationKey, value);
             return value;
         }


### PR DESCRIPTION
Why is not possible to set "renew" parameter at runtime? I usually register Java CAS client filters during context initialization in a ServletContextListener, to have more freedom in parameter definition.
This change permit to also set "renew".