### PR TITLE
Fix of performance issue in Cas20ServiceTicketValidator

### DIFF
--- a/cas-client-core/src/main/java/org/apereo/cas/client/validation/Cas20ServiceTicketValidator.java
+++ b/cas-client-core/src/main/java/org/apereo/cas/client/validation/Cas20ServiceTicketValidator.java
@@ -53,6 +53,11 @@ public class Cas20ServiceTicketValidator extends AbstractCasProtocolUrlBasedTick
     public static final String PGT_ATTRIBUTE = "proxyGrantingTicket";
 
     private static final String PGTIOU_PREFIX = "PGTIOU-";
+    private static final SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+    static {
+        saxParserFactory.setNamespaceAware(true);
+        saxParserFactory.setValidating(false);
+    }
 
     /** The CAS 2.0 protocol proxy callback url. */
     private String proxyCallbackUrl;
@@ -196,11 +201,8 @@ public class Cas20ServiceTicketValidator extends AbstractCasProtocolUrlBasedTick
      * @return the map of attributes.
      */
     protected Map<String, Object> extractCustomAttributes(final String xml) {
-        final var spf = SAXParserFactory.newInstance();
-        spf.setNamespaceAware(true);
-        spf.setValidating(false);
         try {
-            final var saxParser = spf.newSAXParser();
+            final var saxParser = saxParserFactory.newSAXParser();
             final var xmlReader = saxParser.getXMLReader();
             final var handler = new CustomAttributeHandler();
             xmlReader.setContentHandler(handler);


### PR DESCRIPTION
Invocation of SAXParserFactory.newInstance() every time leads to performance issue. Method SAXParserFactory.newInstance() takes a very long time to create a new instance. In my case, I use CAS-Management v6.6.2.  CAS-Management need a long time to pass authentication in CAS. Sometimes, more than 200 seconds. The response from Сas comes almost instantly, however majority of this time takes parsing xml, especially method. 
`protected Map<String, Object> extractCustomAttributes(final String xml)`
Therefore I suggest to initialize the instance SAXParserFactory only once
Example below
Cas-management got response from CAS at 2023-05-23 03:14:51,951, but
Cas-management was able to get  principal only at 2023-05-23 03:15:02,834
Credentials validation took: 10904 ms
Cas-management was run with the setting -Djaxp.debug=1
Sensitive information in log was hidden
Logs
```
2023-05-23 03:14:51,950 DEBUG [org.pac4j.cas.credentials.extractor.TicketAndLogoutRequestExtractor] - <casCredentials: #TokenCredentials# | token: ST-11-mRwj2rqW4Ku1AvYl52-lZLTkCsg-localhost |>
2023-05-23 03:14:51,951 DEBUG [org.jasig.cas.client.validation.Cas30ServiceTicketValidator] - <Placing URL parameters in map.>
2023-05-23 03:14:51,951 DEBUG [org.jasig.cas.client.validation.Cas30ServiceTicketValidator] - <Calling template URL attribute map.>
2023-05-23 03:14:51,951 DEBUG [org.jasig.cas.client.validation.Cas30ServiceTicketValidator] - <Loading custom parameters from configuration.>
2023-05-23 03:14:51,951 DEBUG [org.jasig.cas.client.validation.Cas30ServiceTicketValidator] - <Constructing validation url: http://localhost:8078/cas/p3/serviceValidate?ticket=ST-11-mRwj2rqW4Ku1AvYl52-lZLTkCsg-localhost&service=http%3A%2F%2Flocalhost%3A8443%2Fcas-management%2Fcallback%3Fclient_name%3DCasClient>                                                                                                                                                                  
2023-05-23 03:14:51,951 DEBUG [org.jasig.cas.client.validation.Cas30ServiceTicketValidator] - <Retrieving response from server.>
JAXP: find factoryId =javax.xml.parsers.SAXParserFactory
2023-05-23 03:14:52,087 DEBUG [org.jasig.cas.client.validation.Cas30ServiceTicketValidator] - <Server response: <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
    <cas:authenticationSuccess>                                                                                                                                                                                                              
        ... response                                                                                                                                                                                                              
    </cas:authenticationSuccess>                                                                                                                                                                                                             
</cas:serviceResponse>>                                                                                                                                                                                                                      
2023-05-23 03:14:52,131 DEBUG [org.mongodb.driver.cluster] - <Updating cluster description to  {type=STANDALONE, servers=[{address=localhost:27017, type=STANDALONE, roundTripTime=4.2 ms, state=CONNECTED}]>
2023-05-23 03:14:52,131 DEBUG [org.mongodb.driver.cluster] - <Checking status of localhost:27017>
2023-05-23 03:14:56,753 DEBUG [org.mongodb.driver.protocol.command] - <Sending command '{"hello": 1, "$db": "admin", "$readPreference": {"mode": "primaryPreferred"}}' with request id 52 to database admin on connection [connectionId{localValue:2, serverValue:687}] to server localhost:27017>                                                                                                                                                                                        
2023-05-23 03:14:56,754 DEBUG [org.mongodb.driver.protocol.command] - <Execution of command with request id 52 completed successfully in 1.10 ms on connection [connectionId{localValue:2, serverValue:687}] to server localhost:27017>
2023-05-23 03:14:57,161 DEBUG [org.mongodb.driver.cluster] - <Updating cluster description to  {type=STANDALONE, servers=[{address=localhost:27017, type=STANDALONE, roundTripTime=3.7 ms, state=CONNECTED}]>
2023-05-23 03:14:57,161 DEBUG [org.mongodb.driver.cluster] - <Checking status of localhost:27017>
2023-05-23 03:15:01,764 DEBUG [org.mongodb.driver.protocol.command] - <Sending command '{"hello": 1, "$db": "admin", "$readPreference": {"mode": "primaryPreferred"}}' with request id 53 to database admin on connection [connectionId{localValue:2, serverValue:687}] to server localhost:27017>                                                                                                                                                                                        
2023-05-23 03:15:01,766 DEBUG [org.mongodb.driver.protocol.command] - <Execution of command with request id 53 completed successfully in 2.24 ms on connection [connectionId{localValue:2, serverValue:687}] to server localhost:27017>
2023-05-23 03:15:02,174 DEBUG [org.mongodb.driver.cluster] - <Updating cluster description to  {type=STANDALONE, servers=[{address=localhost:27017, type=STANDALONE, roundTripTime=3.5 ms, state=CONNECTED}]>
2023-05-23 03:15:02,174 DEBUG [org.mongodb.driver.cluster] - <Checking status of localhost:27017>
2023-05-23 03:15:02,690 DEBUG [org.mongodb.driver.connection] - <Closed connection [connectionId{localValue:4, serverValue:694}] to localhost:27017 because it is past its maximum allowed life time.>
2023-05-23 03:15:02,690 DEBUG [org.mongodb.driver.connection] - <Closing connection connectionId{localValue:4, serverValue:694}>
2023-05-23 03:15:02,771 INFO [org.mongodb.driver.connection] - <Opened connection [connectionId{localValue:5, serverValue:699}] to localhost:27017>
2023-05-23 03:15:02,772 DEBUG [org.mongodb.driver.protocol.command] - <Sending command '{"find": "cas-service-registry", "readConcern": {"level": "available"}, "filter": {}, "$db": "cas", "lsid": {"id": {"$binary": {"base64": "8Rdn5hZ0TYSyJHfg+T/anA==", "subType": "04"}}}}' with request id 56 to database cas on connection [connectionId{localValue:5, serverValue:699}] to server localhost:27017>                                                                              
JAXP: find factoryId =javax.xml.parsers.SAXParserFactory
JAXP: find factoryId =javax.xml.parsers.SAXParserFactory
JAXP: find factoryId =javax.xml.parsers.DocumentBuilderFactory
JAXP: find factoryId =javax.xml.parsers.SAXParserFactory
2023-05-23 03:15:02,826 DEBUG [org.mongodb.driver.protocol.command] - <Execution of command with request id 56 completed successfully in 54.24 ms on connection [connectionId{localValue:5, serverValue:699}] to server localhost:27017>
2023-05-23 03:15:02,827 DEBUG [org.mongodb.driver.operation] - <Received batch of 7 documents with cursorId 0 from server localhost:27017>
2023-05-23 03:15:02,832 INFO [org.apereo.cas.services.AbstractServicesManager] - <Loaded [7] service(s) from [EmbeddedResourceBasedServiceRegistry,MongoDbServiceRegistry].>
2023-05-23 03:15:02,834 DEBUG [org.pac4j.cas.credentials.authenticator.CasAuthenticator] - <principal: userprincipal>
... some logs                                                                                                                                                                                                      
2023-05-23 03:15:02,854 DEBUG [org.pac4j.cas.client.CasClient] - <Credentials validation took: 10904 ms>


```

specs
```
CentOS Linux release 7.9.2009 (Core)
4 CPU, 4Gb RAM,
openjdk version "11.0.19" 2023-04-18 LTS
OpenJDK Runtime Environment Zulu11.64+19-CA (build 11.0.19+7-LTS)
OpenJDK 64-Bit Server VM Zulu11.64+19-CA (build 11.0.19+7-LTS, mixed mode)
```
