### PR TITLE
Refactoring for pac4j

### DIFF
--- a/cas-client-core/src/main/java/org/apereo/cas/client/jaas/Servlet3AuthenticationFilter.java
+++ b/cas-client-core/src/main/java/org/apereo/cas/client/jaas/Servlet3AuthenticationFilter.java
@@ -20,7 +20,7 @@ package org.apereo.cas.client.jaas;
 
 import org.apereo.cas.client.Protocol;
 import org.apereo.cas.client.util.AbstractCasFilter;
-import org.apereo.cas.client.util.CommonUtils;
+import org.apereo.cas.client.util.WebUtils;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -60,7 +60,7 @@ public final class Servlet3AuthenticationFilter extends AbstractCasFilter {
         final var request = (HttpServletRequest) servletRequest;
         final var response = (HttpServletResponse) servletResponse;
         final var session = request.getSession();
-        final var ticket = CommonUtils.safeGetParameter(request, getProtocol().getArtifactParameterName());
+        final var ticket = WebUtils.safeGetParameter(request, getProtocol().getArtifactParameterName());
 
         if (session != null && session.getAttribute(CONST_CAS_ASSERTION) == null && ticket != null) {
             try {

--- a/cas-client-core/src/main/java/org/apereo/cas/client/session/SingleSignOutHandler.java
+++ b/cas-client-core/src/main/java/org/apereo/cas/client/session/SingleSignOutHandler.java
@@ -21,6 +21,7 @@ package org.apereo.cas.client.session;
 import org.apereo.cas.client.Protocol;
 import org.apereo.cas.client.configuration.ConfigurationKeys;
 import org.apereo.cas.client.util.CommonUtils;
+import org.apereo.cas.client.util.WebUtils;
 import org.apereo.cas.client.util.XmlUtils;
 
 import jakarta.servlet.ServletException;
@@ -205,7 +206,7 @@ public final class SingleSignOutHandler {
      * @return True if request contains authentication token, false otherwise.
      */
     private boolean isTokenRequest(final HttpServletRequest request) {
-        return CommonUtils.isNotBlank(CommonUtils.safeGetParameter(request, this.artifactParameterName,
+        return CommonUtils.isNotBlank(WebUtils.safeGetParameter(request, this.artifactParameterName,
             this.safeParameters));
     }
 
@@ -220,12 +221,12 @@ public final class SingleSignOutHandler {
         if ("POST".equalsIgnoreCase(request.getMethod())) {
             return !isMultipartRequest(request)
                    && pathEligibleForLogout(request)
-                   && CommonUtils.isNotBlank(CommonUtils.safeGetParameter(request, this.logoutParameterName,
+                   && CommonUtils.isNotBlank(WebUtils.safeGetParameter(request, this.logoutParameterName,
                 this.safeParameters));
         }
 
         if ("GET".equalsIgnoreCase(request.getMethod())) {
-            return CommonUtils.isNotBlank(CommonUtils.safeGetParameter(request, this.logoutParameterName, this.safeParameters));
+            return CommonUtils.isNotBlank(WebUtils.safeGetParameter(request, this.logoutParameterName, this.safeParameters));
         }
         return false;
     }
@@ -252,7 +253,7 @@ public final class SingleSignOutHandler {
             return;
         }
 
-        final var token = CommonUtils.safeGetParameter(request, this.artifactParameterName, this.safeParameters);
+        final var token = WebUtils.safeGetParameter(request, this.artifactParameterName, this.safeParameters);
         logger.debug("Recording session for token {}", token);
 
         try {
@@ -299,7 +300,7 @@ public final class SingleSignOutHandler {
      * @param request HTTP request containing a CAS logout message.
      */
     private void destroySession(final HttpServletRequest request) {
-        var logoutMessage = CommonUtils.safeGetParameter(request, this.logoutParameterName, this.safeParameters);
+        var logoutMessage = WebUtils.safeGetParameter(request, this.logoutParameterName, this.safeParameters);
         if (CommonUtils.isBlank(logoutMessage)) {
             logger.error("Could not locate logout message of the request from {}", this.logoutParameterName);
             return;

--- a/cas-client-core/src/main/java/org/apereo/cas/client/util/AbstractCasFilter.java
+++ b/cas-client-core/src/main/java/org/apereo/cas/client/util/AbstractCasFilter.java
@@ -127,7 +127,7 @@ public abstract class AbstractCasFilter extends AbstractConfigurationFilter {
     }
 
     protected final String constructServiceUrl(final HttpServletRequest request, final HttpServletResponse response) {
-        return CommonUtils.constructServiceUrl(request, response, this.service, this.serverName,
+        return WebUtils.constructServiceUrl(request, response, this.service, this.serverName,
             this.protocol.getServiceParameterName(),
             this.protocol.getArtifactParameterName(), this.encodeServiceUrl);
     }
@@ -143,7 +143,7 @@ public abstract class AbstractCasFilter extends AbstractConfigurationFilter {
      * @return the ticket if its found, null otherwise.
      */
     protected String retrieveTicketFromRequest(final HttpServletRequest request) {
-        return CommonUtils.safeGetParameter(request, this.protocol.getArtifactParameterName(),
+        return WebUtils.safeGetParameter(request, this.protocol.getArtifactParameterName(),
             Collections.singletonList(this.protocol.getArtifactParameterName()));
     }
 }

--- a/cas-client-core/src/main/java/org/apereo/cas/client/util/CommonUtils.java
+++ b/cas-client-core/src/main/java/org/apereo/cas/client/util/CommonUtils.java
@@ -18,17 +18,11 @@
  */
 package org.apereo.cas.client.util;
 
-import org.apereo.cas.client.Protocol;
-import org.apereo.cas.client.proxy.ProxyGrantingTicketStorage;
 import org.apereo.cas.client.ssl.HttpURLConnectionFactory;
 import org.apereo.cas.client.ssl.HttpsURLConnectionFactory;
 import org.apereo.cas.client.validation.ProxyList;
 import org.apereo.cas.client.validation.ProxyListEditor;
 
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,10 +34,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
 
 /**
  * Common utilities so that we don't need to include Commons Lang.
@@ -55,29 +46,7 @@ public final class CommonUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CommonUtils.class);
 
-    /**
-     * Constant representing the ProxyGrantingTicket IOU Request Parameter.
-     */
-    private static final String PARAM_PROXY_GRANTING_TICKET_IOU = "pgtIou";
-
-    /**
-     * Constant representing the ProxyGrantingTicket Request Parameter.
-     */
-    private static final String PARAM_PROXY_GRANTING_TICKET = "pgtId";
-
     private static final HttpURLConnectionFactory DEFAULT_URL_CONNECTION_FACTORY = new HttpsURLConnectionFactory();
-
-    private static final String SERVICE_PARAMETER_NAMES;
-
-    static {
-        final Collection<String> serviceParameterSet = new HashSet<>(4);
-        for (final var protocol : Protocol.values()) {
-            serviceParameterSet.add(protocol.getServiceParameterName());
-        }
-        SERVICE_PARAMETER_NAMES = serviceParameterSet.toString()
-            .replaceAll("\\[|\\]", "")
-            .replaceAll("\\s", "");
-    }
 
     private CommonUtils() {
         // nothing to do
@@ -227,186 +196,6 @@ public final class CommonUtils {
         }
     }
 
-    public static void readAndRespondToProxyReceptorRequest(final ServletRequest request,
-                                                            final ServletResponse response, final ProxyGrantingTicketStorage proxyGrantingTicketStorage)
-        throws IOException {
-        final var proxyGrantingTicketIou = request.getParameter(PARAM_PROXY_GRANTING_TICKET_IOU);
-
-        final var proxyGrantingTicket = request.getParameter(PARAM_PROXY_GRANTING_TICKET);
-
-        if (CommonUtils.isBlank(proxyGrantingTicket) || CommonUtils.isBlank(proxyGrantingTicketIou)) {
-            response.getWriter().write("");
-            return;
-        }
-
-        LOGGER.debug("Received proxyGrantingTicketId [{}] for proxyGrantingTicketIou [{}]", proxyGrantingTicket,
-            proxyGrantingTicketIou);
-
-        proxyGrantingTicketStorage.save(proxyGrantingTicketIou, proxyGrantingTicket);
-
-        LOGGER.debug("Successfully saved proxyGrantingTicketId [{}] for proxyGrantingTicketIou [{}]",
-            proxyGrantingTicket, proxyGrantingTicketIou);
-
-        response.getWriter().write("<?xml version=\"1.0\"?>");
-        response.getWriter().write("<casClient:proxySuccess xmlns:casClient=\"http://www.yale.edu/tp/casClient\" />");
-    }
-
-    private static String findMatchingServerName(final HttpServletRequest request, final String serverName) {
-        final var serverNames = serverName.split(" ");
-
-        if (serverNames.length == 0 || serverNames.length == 1) {
-            return serverName;
-        }
-
-        final var host = request.getHeader("Host");
-        final var xHost = request.getHeader("X-Forwarded-Host");
-
-        final String comparisonHost;
-        comparisonHost = (xHost != null) ? xHost : host;
-
-        if (comparisonHost == null) {
-            return serverName;
-        }
-
-        for (final var server : serverNames) {
-            final var lowerCaseServer = server.toLowerCase();
-
-            if (lowerCaseServer.contains(comparisonHost)) {
-                return server;
-            }
-        }
-
-        return serverNames[0];
-    }
-
-    private static boolean requestIsOnStandardPort(final ServletRequest request) {
-        final var serverPort = request.getServerPort();
-        return serverPort == 80 || serverPort == 443;
-    }
-
-    /**
-     * Constructs a service url from the HttpServletRequest or from the given
-     * serviceUrl. Prefers the serviceUrl provided if both a serviceUrl and a
-     * serviceName. Compiles a list of all service parameters for supported protocols
-     * and removes them all from the query string.
-     *
-     * @param request the HttpServletRequest
-     * @param response the HttpServletResponse
-     * @param service the configured service url (this will be used if not null)
-     * @param serverNames the server name to  use to construct the service url if the service param is empty.  Note, prior to CAS Client 3.3, this was a single value.
-     *           As of 3.3, it can be a space-separated value.  We keep it as a single value, but will convert it to an array internally to get the matching value. This keeps backward compatability with anything using this public
-     *           method.
-     * @param artifactParameterName the artifact parameter name to remove (i.e. ticket)
-     * @param encode whether to encode the url or not (i.e. Jsession).
-     * @return the service url to use.
-     */
-    @Deprecated
-    public static String constructServiceUrl(final HttpServletRequest request, final HttpServletResponse response,
-                                             final String service, final String serverNames,
-                                             final String artifactParameterName, final boolean encode) {
-        return constructServiceUrl(request, response, service, serverNames, SERVICE_PARAMETER_NAMES
-            , artifactParameterName, encode);
-    }
-
-    /**
-     * Constructs a service url from the HttpServletRequest or from the given
-     * serviceUrl. Prefers the serviceUrl provided if both a serviceUrl and a
-     * serviceName.
-     *
-     * @param request the HttpServletRequest
-     * @param response the HttpServletResponse
-     * @param service the configured service url (this will be used if not null)
-     * @param serverNames the server name to  use to construct the service url if the service param is empty.  Note, prior to CAS Client 3.3, this was a single value.
-     *           As of 3.3, it can be a space-separated value.  We keep it as a single value, but will convert it to an array internally to get the matching value. This keeps backward compatability with anything using this public
-     *           method.
-     * @param serviceParameterName the service parameter name to remove (i.e. service)
-     * @param artifactParameterName the artifact parameter name to remove (i.e. ticket)
-     * @param encode whether to encode the url or not (i.e. Jsession).
-     * @return the service url to use.
-     */
-    public static String constructServiceUrl(final HttpServletRequest request, final HttpServletResponse response,
-                                             final String service, final String serverNames, final String serviceParameterName,
-                                             final String artifactParameterName, final boolean encode) {
-        if (CommonUtils.isNotBlank(service)) {
-            return encode ? response.encodeURL(service) : service;
-        }
-
-        final var serverName = findMatchingServerName(request, serverNames);
-        final var originalRequestUrl = new URIBuilder(request.getRequestURL().toString(), encode);
-        originalRequestUrl.setParameters(request.getQueryString());
-
-        final URIBuilder builder;
-        if (!serverName.startsWith("https://") && !serverName.startsWith("http://")) {
-            final var scheme = request.isSecure() ? "https://" : "http://";
-            builder = new URIBuilder(scheme + serverName, encode);
-        } else {
-            builder = new URIBuilder(serverName, encode);
-        }
-
-        if (builder.getPort() == -1 && !requestIsOnStandardPort(request)) {
-            builder.setPort(request.getServerPort());
-        }
-
-        builder.setEncodedPath(builder.getEncodedPath() + request.getRequestURI());
-
-        final var serviceParameterNames = Arrays.asList(serviceParameterName.split(","));
-        if (!serviceParameterNames.isEmpty() && !originalRequestUrl.getQueryParams().isEmpty()) {
-            for (final var pair : originalRequestUrl.getQueryParams()) {
-                final var name = pair.name();
-                if (!name.equals(artifactParameterName) && !serviceParameterNames.contains(name)) {
-                    if (name.contains("&") || name.contains("=")) {
-                        final var encodedParamBuilder = new URIBuilder();
-                        encodedParamBuilder.setParameters(name);
-                        for (final var pair2 : encodedParamBuilder.getQueryParams()) {
-                            final var name2 = pair2.name();
-                            if (!name2.equals(artifactParameterName) && !serviceParameterNames.contains(name2)) {
-                                builder.addParameter(name2, pair2.value());
-                            }
-                        }
-                    } else {
-                        builder.addParameter(name, pair.value());
-                    }
-                }
-            }
-        }
-
-        final var result = builder.toString();
-        final var returnValue = encode ? response.encodeURL(result) : result;
-        LOGGER.debug("serviceUrl generated: {}", returnValue);
-        return returnValue;
-    }
-
-    /**
-     * Safe method for retrieving a parameter from the request without disrupting the reader UNLESS the parameter
-     * actually exists in the query string.
-     * <p>
-     * Note, this does not work for POST Requests for "logoutRequest".  It works for all other CAS POST requests because the
-     * parameter is ALWAYS in the GET request.
-     * <p>
-     * If we see the "logoutRequest" parameter we MUST treat it as if calling the standard request.getParameter.
-     * <p>
-     *     Note, that as of 3.3.0, we've made it more generic.
-     * </p>
-     *
-     * @param request the request to check.
-     * @param parameter the parameter to look for.
-     * @return the value of the parameter.
-     */
-    public static String safeGetParameter(final HttpServletRequest request, final String parameter,
-                                          final Collection<String> parameters) {
-        if ("POST".equals(request.getMethod()) && parameters.contains(parameter)) {
-            LOGGER.debug("safeGetParameter called on a POST HttpServletRequest for Restricted Parameters.  Cannot complete check safely.  Reverting to standard behavior for this Parameter");
-            return request.getParameter(parameter);
-        }
-        return request.getQueryString() == null || !request.getQueryString().contains(parameter) ? null : request
-            .getParameter(parameter);
-    }
-
-    public static String safeGetParameter(final HttpServletRequest request, final String parameter) {
-        return safeGetParameter(request, parameter, List.of("logoutRequest"));
-    }
-
-
     /**
      * Contacts the remote URL and returns the response.
      *
@@ -482,21 +271,6 @@ public final class CommonUtils {
         final var editor = new ProxyListEditor();
         editor.setAsText(proxies);
         return (ProxyList) editor.getValue();
-    }
-
-    /**
-     * Sends the redirect message and captures the exceptions that we can't possibly do anything with.
-     *
-     * @param response the HttpServletResponse.  CANNOT be NULL.
-     * @param url the url to redirect to.
-     */
-    public static void sendRedirect(final HttpServletResponse response, final String url) {
-        try {
-            response.sendRedirect(url);
-        } catch (final IOException e) {
-            LOGGER.warn(e.getMessage(), e);
-        }
-
     }
 
     /**

--- a/cas-client-core/src/main/java/org/apereo/cas/client/util/DelegatingFilter.java
+++ b/cas-client-core/src/main/java/org/apereo/cas/client/util/DelegatingFilter.java
@@ -92,7 +92,7 @@ public final class DelegatingFilter implements Filter {
     public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain filterChain)
         throws IOException, ServletException {
 
-        final var parameter = CommonUtils.safeGetParameter((HttpServletRequest) request, this.requestParameterName);
+        final var parameter = WebUtils.safeGetParameter((HttpServletRequest) request, this.requestParameterName);
 
         if (CommonUtils.isNotEmpty(parameter)) {
             for (final var key : this.delegators.keySet()) {

--- a/cas-client-core/src/main/java/org/apereo/cas/client/util/WebUtils.java
+++ b/cas-client-core/src/main/java/org/apereo/cas/client/util/WebUtils.java
@@ -35,7 +35,7 @@ import java.util.HashSet;
 import java.util.List;
 
 /**
- * Commons utilities related to the Jakarta request/response.
+ * Commons utilities related to the web (Jakarta) request/response.
  *
  * @author Jerome LELEU
  * @since 4.0.3
@@ -64,6 +64,9 @@ public final class WebUtils {
         SERVICE_PARAMETER_NAMES = serviceParameterSet.toString()
                 .replaceAll("\\[|\\]", "")
                 .replaceAll("\\s", "");
+    }
+
+    private WebUtils() {
     }
 
     public static void readAndRespondToProxyReceptorRequest(final ServletRequest request,

--- a/cas-client-core/src/main/java/org/apereo/cas/client/util/WebUtils.java
+++ b/cas-client-core/src/main/java/org/apereo/cas/client/util/WebUtils.java
@@ -1,0 +1,261 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apereo.cas.client.util;
+
+import org.apereo.cas.client.Protocol;
+import org.apereo.cas.client.proxy.ProxyGrantingTicketStorage;
+
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * Commons utilities related to the Jakarta request/response.
+ *
+ * @author Jerome LELEU
+ * @since 4.0.3
+ */
+public final class WebUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebUtils.class);
+
+    /**
+     * Constant representing the ProxyGrantingTicket IOU Request Parameter.
+     */
+    private static final String PARAM_PROXY_GRANTING_TICKET_IOU = "pgtIou";
+
+    /**
+     * Constant representing the ProxyGrantingTicket Request Parameter.
+     */
+    private static final String PARAM_PROXY_GRANTING_TICKET = "pgtId";
+
+    private static final String SERVICE_PARAMETER_NAMES;
+
+    static {
+        final Collection<String> serviceParameterSet = new HashSet<>(4);
+        for (final var protocol : Protocol.values()) {
+            serviceParameterSet.add(protocol.getServiceParameterName());
+        }
+        SERVICE_PARAMETER_NAMES = serviceParameterSet.toString()
+                .replaceAll("\\[|\\]", "")
+                .replaceAll("\\s", "");
+    }
+
+    public static void readAndRespondToProxyReceptorRequest(final ServletRequest request,
+                                                            final ServletResponse response, final ProxyGrantingTicketStorage proxyGrantingTicketStorage)
+        throws IOException {
+        final var proxyGrantingTicketIou = request.getParameter(PARAM_PROXY_GRANTING_TICKET_IOU);
+
+        final var proxyGrantingTicket = request.getParameter(PARAM_PROXY_GRANTING_TICKET);
+
+        if (CommonUtils.isBlank(proxyGrantingTicket) || CommonUtils.isBlank(proxyGrantingTicketIou)) {
+            response.getWriter().write("");
+            return;
+        }
+
+        LOGGER.debug("Received proxyGrantingTicketId [{}] for proxyGrantingTicketIou [{}]", proxyGrantingTicket,
+            proxyGrantingTicketIou);
+
+        proxyGrantingTicketStorage.save(proxyGrantingTicketIou, proxyGrantingTicket);
+
+        LOGGER.debug("Successfully saved proxyGrantingTicketId [{}] for proxyGrantingTicketIou [{}]",
+            proxyGrantingTicket, proxyGrantingTicketIou);
+
+        response.getWriter().write("<?xml version=\"1.0\"?>");
+        response.getWriter().write("<casClient:proxySuccess xmlns:casClient=\"http://www.yale.edu/tp/casClient\" />");
+    }
+
+    private static String findMatchingServerName(final HttpServletRequest request, final String serverName) {
+        final var serverNames = serverName.split(" ");
+
+        if (serverNames.length == 0 || serverNames.length == 1) {
+            return serverName;
+        }
+
+        final var host = request.getHeader("Host");
+        final var xHost = request.getHeader("X-Forwarded-Host");
+
+        final String comparisonHost;
+        comparisonHost = (xHost != null) ? xHost : host;
+
+        if (comparisonHost == null) {
+            return serverName;
+        }
+
+        for (final var server : serverNames) {
+            final var lowerCaseServer = server.toLowerCase();
+
+            if (lowerCaseServer.contains(comparisonHost)) {
+                return server;
+            }
+        }
+
+        return serverNames[0];
+    }
+
+    private static boolean requestIsOnStandardPort(final ServletRequest request) {
+        final var serverPort = request.getServerPort();
+        return serverPort == 80 || serverPort == 443;
+    }
+
+    /**
+     * Constructs a service url from the HttpServletRequest or from the given
+     * serviceUrl. Prefers the serviceUrl provided if both a serviceUrl and a
+     * serviceName. Compiles a list of all service parameters for supported protocols
+     * and removes them all from the query string.
+     *
+     * @param request the HttpServletRequest
+     * @param response the HttpServletResponse
+     * @param service the configured service url (this will be used if not null)
+     * @param serverNames the server name to  use to construct the service url if the service param is empty.  Note, prior to CAS Client 3.3, this was a single value.
+     *           As of 3.3, it can be a space-separated value.  We keep it as a single value, but will convert it to an array internally to get the matching value. This keeps backward compatability with anything using this public
+     *           method.
+     * @param artifactParameterName the artifact parameter name to remove (i.e. ticket)
+     * @param encode whether to encode the url or not (i.e. Jsession).
+     * @return the service url to use.
+     */
+    @Deprecated
+    public static String constructServiceUrl(final HttpServletRequest request, final HttpServletResponse response,
+                                             final String service, final String serverNames,
+                                             final String artifactParameterName, final boolean encode) {
+        return constructServiceUrl(request, response, service, serverNames, SERVICE_PARAMETER_NAMES
+            , artifactParameterName, encode);
+    }
+
+    /**
+     * Constructs a service url from the HttpServletRequest or from the given
+     * serviceUrl. Prefers the serviceUrl provided if both a serviceUrl and a
+     * serviceName.
+     *
+     * @param request the HttpServletRequest
+     * @param response the HttpServletResponse
+     * @param service the configured service url (this will be used if not null)
+     * @param serverNames the server name to  use to construct the service url if the service param is empty.  Note, prior to CAS Client 3.3, this was a single value.
+     *           As of 3.3, it can be a space-separated value.  We keep it as a single value, but will convert it to an array internally to get the matching value. This keeps backward compatability with anything using this public
+     *           method.
+     * @param serviceParameterName the service parameter name to remove (i.e. service)
+     * @param artifactParameterName the artifact parameter name to remove (i.e. ticket)
+     * @param encode whether to encode the url or not (i.e. Jsession).
+     * @return the service url to use.
+     */
+    public static String constructServiceUrl(final HttpServletRequest request, final HttpServletResponse response,
+                                             final String service, final String serverNames, final String serviceParameterName,
+                                             final String artifactParameterName, final boolean encode) {
+        if (CommonUtils.isNotBlank(service)) {
+            return encode ? response.encodeURL(service) : service;
+        }
+
+        final var serverName = findMatchingServerName(request, serverNames);
+        final var originalRequestUrl = new URIBuilder(request.getRequestURL().toString(), encode);
+        originalRequestUrl.setParameters(request.getQueryString());
+
+        final URIBuilder builder;
+        if (!serverName.startsWith("https://") && !serverName.startsWith("http://")) {
+            final var scheme = request.isSecure() ? "https://" : "http://";
+            builder = new URIBuilder(scheme + serverName, encode);
+        } else {
+            builder = new URIBuilder(serverName, encode);
+        }
+
+        if (builder.getPort() == -1 && !requestIsOnStandardPort(request)) {
+            builder.setPort(request.getServerPort());
+        }
+
+        builder.setEncodedPath(builder.getEncodedPath() + request.getRequestURI());
+
+        final var serviceParameterNames = Arrays.asList(serviceParameterName.split(","));
+        if (!serviceParameterNames.isEmpty() && !originalRequestUrl.getQueryParams().isEmpty()) {
+            for (final var pair : originalRequestUrl.getQueryParams()) {
+                final var name = pair.name();
+                if (!name.equals(artifactParameterName) && !serviceParameterNames.contains(name)) {
+                    if (name.contains("&") || name.contains("=")) {
+                        final var encodedParamBuilder = new URIBuilder();
+                        encodedParamBuilder.setParameters(name);
+                        for (final var pair2 : encodedParamBuilder.getQueryParams()) {
+                            final var name2 = pair2.name();
+                            if (!name2.equals(artifactParameterName) && !serviceParameterNames.contains(name2)) {
+                                builder.addParameter(name2, pair2.value());
+                            }
+                        }
+                    } else {
+                        builder.addParameter(name, pair.value());
+                    }
+                }
+            }
+        }
+
+        final var result = builder.toString();
+        final var returnValue = encode ? response.encodeURL(result) : result;
+        LOGGER.debug("serviceUrl generated: {}", returnValue);
+        return returnValue;
+    }
+
+    /**
+     * Safe method for retrieving a parameter from the request without disrupting the reader UNLESS the parameter
+     * actually exists in the query string.
+     * <p>
+     * Note, this does not work for POST Requests for "logoutRequest".  It works for all other CAS POST requests because the
+     * parameter is ALWAYS in the GET request.
+     * <p>
+     * If we see the "logoutRequest" parameter we MUST treat it as if calling the standard request.getParameter.
+     * <p>
+     *     Note, that as of 3.3.0, we've made it more generic.
+     * </p>
+     *
+     * @param request the request to check.
+     * @param parameter the parameter to look for.
+     * @return the value of the parameter.
+     */
+    public static String safeGetParameter(final HttpServletRequest request, final String parameter,
+                                          final Collection<String> parameters) {
+        if ("POST".equals(request.getMethod()) && parameters.contains(parameter)) {
+            LOGGER.debug("safeGetParameter called on a POST HttpServletRequest for Restricted Parameters.  Cannot complete check safely.  Reverting to standard behavior for this Parameter");
+            return request.getParameter(parameter);
+        }
+        return request.getQueryString() == null || !request.getQueryString().contains(parameter) ? null : request
+            .getParameter(parameter);
+    }
+
+    public static String safeGetParameter(final HttpServletRequest request, final String parameter) {
+        return safeGetParameter(request, parameter, List.of("logoutRequest"));
+    }
+
+    /**
+     * Sends the redirect message and captures the exceptions that we can't possibly do anything with.
+     *
+     * @param response the HttpServletResponse.  CANNOT be NULL.
+     * @param url the url to redirect to.
+     */
+    public static void sendRedirect(final HttpServletResponse response, final String url) {
+        try {
+            response.sendRedirect(url);
+        } catch (final IOException e) {
+            LOGGER.warn(e.getMessage(), e);
+        }
+    }
+}

--- a/cas-client-core/src/main/java/org/apereo/cas/client/validation/Cas20ProxyReceivingTicketValidationFilter.java
+++ b/cas-client-core/src/main/java/org/apereo/cas/client/validation/Cas20ProxyReceivingTicketValidationFilter.java
@@ -28,6 +28,7 @@ import org.apereo.cas.client.proxy.ProxyGrantingTicketStorageImpl;
 import org.apereo.cas.client.ssl.HttpURLConnectionFactory;
 import org.apereo.cas.client.ssl.HttpsURLConnectionFactory;
 import org.apereo.cas.client.util.CommonUtils;
+import org.apereo.cas.client.util.WebUtils;
 import org.apereo.cas.client.util.PrivateKeyUtils;
 import org.apereo.cas.client.util.ReflectUtils;
 
@@ -232,7 +233,7 @@ public class Cas20ProxyReceivingTicketValidationFilter extends AbstractTicketVal
         }
 
         try {
-            CommonUtils.readAndRespondToProxyReceptorRequest(request, response, this.proxyGrantingTicketStorage);
+            WebUtils.readAndRespondToProxyReceptorRequest(request, response, this.proxyGrantingTicketStorage);
         } catch (final RuntimeException e) {
             logger.error(e.getMessage(), e);
             throw e;

--- a/cas-client-core/src/test/java/org/apereo/cas/client/util/CommonUtilsTests.java
+++ b/cas-client-core/src/test/java/org/apereo/cas/client/util/CommonUtilsTests.java
@@ -18,15 +18,10 @@
  */
 package org.apereo.cas.client.util;
 
-import org.apereo.cas.client.Protocol;
 import org.apereo.cas.client.PublicTestHttpServer;
 import org.apereo.cas.client.ssl.HttpsURLConnectionFactory;
 
 import junit.framework.TestCase;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
-
-import jakarta.servlet.http.HttpServletResponse;
 
 import java.net.URL;
 import java.util.ArrayList;
@@ -137,177 +132,6 @@ public final class CommonUtilsTests extends TestCase {
         assertFalse(CommonUtils.isNotBlank("   "));
     }
 
-    public void testConstructServiceUrlWithTrailingSlash() {
-        final var CONST_MY_URL = "https://www.myserver.com/hello/hithere/";
-        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.setScheme("https");
-        request.setSecure(true);
-        final HttpServletResponse response = new MockHttpServletResponse();
-        final var constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
-            "service", "ticket", false);
-
-        assertEquals(CONST_MY_URL, constructedUrl);
-    }
-
-    public void testConstructServiceUrlWithServerNameContainingPath() {
-        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.setScheme("https");
-        request.setSecure(true);
-        final HttpServletResponse response = new MockHttpServletResponse();
-        final var constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.my.server.com/app",
-            Protocol.CAS3.getServiceParameterName(), Protocol.CAS3.getArtifactParameterName(), false);
-
-        assertEquals("https://www.my.server.com/app/hello/hithere/", constructedUrl);
-    }
-
-    public void testConstructServiceUrlWithServerNameContainingPathAndSchema() {
-        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.setScheme("https");
-        request.setSecure(true);
-        final HttpServletResponse response = new MockHttpServletResponse();
-        final var constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "https://www.my.server.com/app",
-            Protocol.CAS3.getServiceParameterName(), Protocol.CAS3.getArtifactParameterName(), false);
-
-        assertEquals("https://www.my.server.com/app/hello/hithere/", constructedUrl);
-    }
-
-    public void testConstructServiceUrlWithParamsCas() {
-        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.setScheme("https");
-        request.setSecure(true);
-        request.setQueryString("service=this&ticket=that&custom=custom");
-
-        final HttpServletResponse response = new MockHttpServletResponse();
-        final var constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
-            Protocol.CAS3.getServiceParameterName(), Protocol.CAS3.getArtifactParameterName(), false);
-
-        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
-    }
-
-    public void testConstructServiceUrlWithParamsCasAndServerNameWithSchema() {
-        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.setScheme("https");
-        request.setSecure(true);
-        request.setQueryString("service=this&ticket=that&custom=custom");
-
-        final HttpServletResponse response = new MockHttpServletResponse();
-        final var constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "https://www.myserver.com",
-            Protocol.CAS3.getServiceParameterName(), Protocol.CAS3.getArtifactParameterName(), false);
-
-        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
-    }
-
-
-    public void testConstructServiceUrlWithParamsSaml() {
-        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.setScheme("https");
-        request.setSecure(true);
-        request.setQueryString("TARGET=this&SAMLart=that&custom=custom");
-
-        final HttpServletResponse response = new MockHttpServletResponse();
-        final var constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
-            Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName(), false);
-
-        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
-    }
-
-    public void testConstructServiceUrlWithEncodedParamsSaml() {
-        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.setScheme("https");
-        request.setSecure(true);
-        request.setQueryString("TARGET%3Dthis%26SAMLart%3Dthat%26custom%3Dcustom");
-
-        final HttpServletResponse response = new MockHttpServletResponse();
-        final var constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
-            Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName(), false);
-
-        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
-    }
-
-    public void testConstructServiceUrlWithNoServiceParametersPassed() {
-        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.setScheme("https");
-        request.setSecure(true);
-        request.setQueryString("TARGET=Test1&service=Test2&custom=custom");
-
-        final HttpServletResponse response = new MockHttpServletResponse();
-        final var constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
-            Protocol.SAML11.getArtifactParameterName(), true);
-
-        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
-    }
-
-    public void testConstructServiceUrlWithEncodedParams2Saml() {
-        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.setScheme("https");
-        request.setSecure(true);
-        request.setQueryString("TARGET%3Dthis%26SAMLart%3Dthat%26custom%3Dcustom%20value%20here%26another%3Dgood");
-
-        final HttpServletResponse response = new MockHttpServletResponse();
-        final var constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
-            Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName(), true);
-
-        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom+value+here&another=good", constructedUrl);
-    }
-
-    public void testConstructServiceUrlWithoutEncodedParamsSamlAndNoEncoding() {
-        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.setScheme("https");
-        request.setSecure(true);
-        request.setQueryString("TARGET=this&SAMLart=that&custom=custom value here&another=good");
-
-        final HttpServletResponse response = new MockHttpServletResponse();
-        final var constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
-            Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName(), false);
-
-        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom value here&another=good", constructedUrl);
-    }
-
-    public void testConstructServiceUrlWithEncodedParamsSamlAndNoEncoding() {
-        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.setScheme("https");
-        request.setSecure(true);
-        request.setQueryString("TARGET=this&SAMLart=that&custom=custom+value+here&another=good");
-
-        final HttpServletResponse response = new MockHttpServletResponse();
-        final var constructedUrl = CommonUtils.constructServiceUrl(request, response, null, "www.myserver.com",
-            Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName(), true);
-
-        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom+value+here&another=good", constructedUrl);
-    }
-
-    public void testConstructUrlNonStandardPortAndNoScheme() {
-        constructUrlNonStandardPortAndNoPortInConfigTest("www.myserver.com");
-    }
-
-    public void testConstructUrlNonStandardPortAndScheme() {
-        constructUrlNonStandardPortAndNoPortInConfigTest("https://www.myserver.com");
-    }
-
-    public void testConstructUrlWithMultipleHostsNoPortsOrProtocol() {
-        final var CONST_MY_URL = "https://www.myserver.com/hello/hithere/";
-        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.addHeader("Host", "www.myserver.com");
-        request.setScheme("https");
-        request.setSecure(true);
-        final HttpServletResponse response = new MockHttpServletResponse();
-        final var constructedUrl = CommonUtils.constructServiceUrl(request, response, null,
-            "www.amazon.com www.bestbuy.com www.myserver.com", "service", "ticket", false);
-        assertEquals(CONST_MY_URL, constructedUrl);
-    }
-
-    public void testConstructURlWithMultipleHostsAndPorts() {
-        final var CONST_MY_URL = "https://www.myserver.com/hello/hithere/";
-        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.addHeader("Host", "www.myserver.com");
-        request.setScheme("https");
-        request.setSecure(true);
-        final HttpServletResponse response = new MockHttpServletResponse();
-        final var constructedUrl = CommonUtils.constructServiceUrl(request, response, null,
-            "http://www.amazon.com https://www.bestbuy.com https://www.myserver.com", "service", "ticket", false);
-        assertEquals(CONST_MY_URL, constructedUrl);
-    }
-
     public void testGetResponseFromServer() throws Exception {
         final var RESPONSE = "test1\r\ntest2";
         server.content = RESPONSE.getBytes(server.encoding);
@@ -318,33 +142,6 @@ public final class CommonUtilsTests extends TestCase {
 
     public void testUrlEncode() {
         assertEquals("this+is+a+very+special+parameter+with+%3D%25%2F",
-            CommonUtils.urlEncode("this is a very special parameter with =%/"));
-    }
-
-    public void testUrlEncodeWithQueryParameters() {
-        final var request = new MockHttpServletRequest("GET", "/idp/authN/ExtCas");
-        request.setQueryString("conversation=e1s1&ticket=ST-1234-123456789-a&entityId=https://test.edu/sp?alias=1234-1234-1234-1234&something=else");
-        request.addHeader("Host", "www.myserver.com");
-        request.setScheme("https");
-        request.setSecure(true);
-        final HttpServletResponse response = new MockHttpServletResponse();
-        final var constructedUrl = CommonUtils.constructServiceUrl(request, response, null,
-            "https://my.server.com",
-            "service", "ticket", false);
-        assertEquals("https://my.server.com/idp/authN/ExtCas?conversation=e1s1&entityId=https://test.edu/sp?alias=1234-1234-1234-1234&something=else",
-            constructedUrl);
-    }
-
-    private static void constructUrlNonStandardPortAndNoPortInConfigTest(final String serverNameList) {
-        final var CONST_MY_URL = "https://www.myserver.com:555/hello/hithere/";
-        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
-        request.addHeader("Host", "www.myserver.com");
-        request.setScheme("https");
-        request.setSecure(true);
-        request.setServerPort(555);
-        final HttpServletResponse response = new MockHttpServletResponse();
-        final var constructedUrl = CommonUtils.constructServiceUrl(request, response, null,
-            serverNameList, "service", "ticket", false);
-        assertEquals(CONST_MY_URL, constructedUrl);
+                CommonUtils.urlEncode("this is a very special parameter with =%/"));
     }
 }

--- a/cas-client-core/src/test/java/org/apereo/cas/client/util/WebUtilsTests.java
+++ b/cas-client-core/src/test/java/org/apereo/cas/client/util/WebUtilsTests.java
@@ -1,0 +1,233 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apereo.cas.client.util;
+
+import org.apereo.cas.client.Protocol;
+
+import jakarta.servlet.http.HttpServletResponse;
+import junit.framework.TestCase;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * Tests for the WebUtils.
+ *
+ * @author Jerome LELEU
+ * @since 4.0.3
+ */
+public final class WebUtilsTests extends TestCase {
+
+    public void testConstructServiceUrlWithTrailingSlash() {
+        final var CONST_MY_URL = "https://www.myserver.com/hello/hithere/";
+        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
+        request.setScheme("https");
+        request.setSecure(true);
+        final HttpServletResponse response = new MockHttpServletResponse();
+        final var constructedUrl = WebUtils.constructServiceUrl(request, response, null, "www.myserver.com",
+                "service", "ticket", false);
+
+        assertEquals(CONST_MY_URL, constructedUrl);
+    }
+
+    public void testConstructServiceUrlWithServerNameContainingPath() {
+        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
+        request.setScheme("https");
+        request.setSecure(true);
+        final HttpServletResponse response = new MockHttpServletResponse();
+        final var constructedUrl = WebUtils.constructServiceUrl(request, response, null, "www.my.server.com/app",
+                Protocol.CAS3.getServiceParameterName(), Protocol.CAS3.getArtifactParameterName(), false);
+
+        assertEquals("https://www.my.server.com/app/hello/hithere/", constructedUrl);
+    }
+
+    public void testConstructServiceUrlWithServerNameContainingPathAndSchema() {
+        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
+        request.setScheme("https");
+        request.setSecure(true);
+        final HttpServletResponse response = new MockHttpServletResponse();
+        final var constructedUrl = WebUtils.constructServiceUrl(request, response, null, "https://www.my.server.com/app",
+                Protocol.CAS3.getServiceParameterName(), Protocol.CAS3.getArtifactParameterName(), false);
+
+        assertEquals("https://www.my.server.com/app/hello/hithere/", constructedUrl);
+    }
+
+    public void testConstructServiceUrlWithParamsCas() {
+        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
+        request.setScheme("https");
+        request.setSecure(true);
+        request.setQueryString("service=this&ticket=that&custom=custom");
+
+        final HttpServletResponse response = new MockHttpServletResponse();
+        final var constructedUrl = WebUtils.constructServiceUrl(request, response, null, "www.myserver.com",
+                Protocol.CAS3.getServiceParameterName(), Protocol.CAS3.getArtifactParameterName(), false);
+
+        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
+    }
+
+    public void testConstructServiceUrlWithParamsCasAndServerNameWithSchema() {
+        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
+        request.setScheme("https");
+        request.setSecure(true);
+        request.setQueryString("service=this&ticket=that&custom=custom");
+
+        final HttpServletResponse response = new MockHttpServletResponse();
+        final var constructedUrl = WebUtils.constructServiceUrl(request, response, null, "https://www.myserver.com",
+                Protocol.CAS3.getServiceParameterName(), Protocol.CAS3.getArtifactParameterName(), false);
+
+        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
+    }
+
+
+    public void testConstructServiceUrlWithParamsSaml() {
+        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
+        request.setScheme("https");
+        request.setSecure(true);
+        request.setQueryString("TARGET=this&SAMLart=that&custom=custom");
+
+        final HttpServletResponse response = new MockHttpServletResponse();
+        final var constructedUrl = WebUtils.constructServiceUrl(request, response, null, "www.myserver.com",
+                Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName(), false);
+
+        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
+    }
+
+    public void testConstructServiceUrlWithEncodedParamsSaml() {
+        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
+        request.setScheme("https");
+        request.setSecure(true);
+        request.setQueryString("TARGET%3Dthis%26SAMLart%3Dthat%26custom%3Dcustom");
+
+        final HttpServletResponse response = new MockHttpServletResponse();
+        final var constructedUrl = WebUtils.constructServiceUrl(request, response, null, "www.myserver.com",
+                Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName(), false);
+
+        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
+    }
+
+    public void testConstructServiceUrlWithNoServiceParametersPassed() {
+        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
+        request.setScheme("https");
+        request.setSecure(true);
+        request.setQueryString("TARGET=Test1&service=Test2&custom=custom");
+
+        final HttpServletResponse response = new MockHttpServletResponse();
+        final var constructedUrl = WebUtils.constructServiceUrl(request, response, null, "www.myserver.com",
+                Protocol.SAML11.getArtifactParameterName(), true);
+
+        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom", constructedUrl);
+    }
+
+    public void testConstructServiceUrlWithEncodedParams2Saml() {
+        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
+        request.setScheme("https");
+        request.setSecure(true);
+        request.setQueryString("TARGET%3Dthis%26SAMLart%3Dthat%26custom%3Dcustom%20value%20here%26another%3Dgood");
+
+        final HttpServletResponse response = new MockHttpServletResponse();
+        final var constructedUrl = WebUtils.constructServiceUrl(request, response, null, "www.myserver.com",
+                Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName(), true);
+
+        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom+value+here&another=good", constructedUrl);
+    }
+
+    public void testConstructServiceUrlWithoutEncodedParamsSamlAndNoEncoding() {
+        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
+        request.setScheme("https");
+        request.setSecure(true);
+        request.setQueryString("TARGET=this&SAMLart=that&custom=custom value here&another=good");
+
+        final HttpServletResponse response = new MockHttpServletResponse();
+        final var constructedUrl = WebUtils.constructServiceUrl(request, response, null, "www.myserver.com",
+                Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName(), false);
+
+        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom value here&another=good", constructedUrl);
+    }
+
+    public void testConstructServiceUrlWithEncodedParamsSamlAndNoEncoding() {
+        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
+        request.setScheme("https");
+        request.setSecure(true);
+        request.setQueryString("TARGET=this&SAMLart=that&custom=custom+value+here&another=good");
+
+        final HttpServletResponse response = new MockHttpServletResponse();
+        final var constructedUrl = WebUtils.constructServiceUrl(request, response, null, "www.myserver.com",
+                Protocol.SAML11.getServiceParameterName(), Protocol.SAML11.getArtifactParameterName(), true);
+
+        assertEquals("https://www.myserver.com/hello/hithere/?custom=custom+value+here&another=good", constructedUrl);
+    }
+
+    public void testConstructUrlNonStandardPortAndNoScheme() {
+        constructUrlNonStandardPortAndNoPortInConfigTest("www.myserver.com");
+    }
+
+    public void testConstructUrlNonStandardPortAndScheme() {
+        constructUrlNonStandardPortAndNoPortInConfigTest("https://www.myserver.com");
+    }
+
+    public void testConstructUrlWithMultipleHostsNoPortsOrProtocol() {
+        final var CONST_MY_URL = "https://www.myserver.com/hello/hithere/";
+        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
+        request.addHeader("Host", "www.myserver.com");
+        request.setScheme("https");
+        request.setSecure(true);
+        final HttpServletResponse response = new MockHttpServletResponse();
+        final var constructedUrl = WebUtils.constructServiceUrl(request, response, null,
+                "www.amazon.com www.bestbuy.com www.myserver.com", "service", "ticket", false);
+        assertEquals(CONST_MY_URL, constructedUrl);
+    }
+
+    public void testConstructURlWithMultipleHostsAndPorts() {
+        final var CONST_MY_URL = "https://www.myserver.com/hello/hithere/";
+        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
+        request.addHeader("Host", "www.myserver.com");
+        request.setScheme("https");
+        request.setSecure(true);
+        final HttpServletResponse response = new MockHttpServletResponse();
+        final var constructedUrl = WebUtils.constructServiceUrl(request, response, null,
+                "http://www.amazon.com https://www.bestbuy.com https://www.myserver.com", "service", "ticket", false);
+        assertEquals(CONST_MY_URL, constructedUrl);
+    }
+
+    public void testUrlEncodeWithQueryParameters() {
+        final var request = new MockHttpServletRequest("GET", "/idp/authN/ExtCas");
+        request.setQueryString("conversation=e1s1&ticket=ST-1234-123456789-a&entityId=https://test.edu/sp?alias=1234-1234-1234-1234&something=else");
+        request.addHeader("Host", "www.myserver.com");
+        request.setScheme("https");
+        request.setSecure(true);
+        final HttpServletResponse response = new MockHttpServletResponse();
+        final var constructedUrl = WebUtils.constructServiceUrl(request, response, null,
+                "https://my.server.com",
+                "service", "ticket", false);
+        assertEquals("https://my.server.com/idp/authN/ExtCas?conversation=e1s1&entityId=https://test.edu/sp?alias=1234-1234-1234-1234&something=else",
+                constructedUrl);
+    }
+
+    private static void constructUrlNonStandardPortAndNoPortInConfigTest(final String serverNameList) {
+        final var CONST_MY_URL = "https://www.myserver.com:555/hello/hithere/";
+        final var request = new MockHttpServletRequest("GET", "/hello/hithere/");
+        request.addHeader("Host", "www.myserver.com");
+        request.setScheme("https");
+        request.setSecure(true);
+        request.setServerPort(555);
+        final HttpServletResponse response = new MockHttpServletResponse();
+        final var constructedUrl = WebUtils.constructServiceUrl(request, response, null,
+                serverNameList, "service", "ticket", false);
+        assertEquals(CONST_MY_URL, constructedUrl);
+    }
+}


### PR DESCRIPTION
pac4j is agnostic from any web implementation, whether it is javax, jakarta, Play framework, Vert.x and so on.

The CAS support of pac4j (`pac4j-cas` module) relies on the Apereo CAS client.

To limit the bonding between the CAS client and the web framework (Jakarta), the related utility methods are moved out of the `CommonUtils` into a new `WebUtils` component.
