### PR TITLE
Fix concurrent issue in SingleSignOutFilter#doFilter method

### DIFF
--- a/cas-client-core/src/main/java/org/apereo/cas/client/session/SingleSignOutFilter.java
+++ b/cas-client-core/src/main/java/org/apereo/cas/client/session/SingleSignOutFilter.java
@@ -94,8 +94,13 @@ public final class SingleSignOutFilter extends AbstractConfigurationFilter {
          * <p>Workaround for now for the fact that Spring Security will fail since it doesn't call {@link #init(javax.servlet.FilterConfig)}.</p>
          * <p>Ultimately we need to allow deployers to actually inject their fully-initialized {@link SingleSignOutHandler}.</p>
          */
-        if (!this.handlerInitialized.getAndSet(true)) {
-            HANDLER.init();
+        if (!this.handlerInitialized.get()) {
+            synchronized (this) {
+                if (!this.handlerInitialized.get()) {
+                    HANDLER.init();
+                    this.handlerInitialized.set(true);
+                }
+            }
         }
 
         if (HANDLER.process(request, response)) {


### PR DESCRIPTION
Fix concurrency issues in `SingleSignOutFilter#doFilter` method.

In the `SingleSignOutFilter#doFilter` method, synchronization is added to prevent concurrent execution and ensure thread safety.
Before the repair, if `SingleSignOutFilter#init `is not executed for initialization, when multiple threads execute concurrently, one thread may be executing the `HANDLER.init()` method, the safeParameters in `SingleSignOutHandler` have not yet been initialized, and other threads have begun executing `HANDLER.process(request, response)`, which will causes the program to throw a NullPointerException.