### PR TITLE
Method to retrieve the ProxyGrantingTicket in AttributePrincipalImpl

### DIFF
--- a/cas-client-core/src/main/java/org/apereo/cas/client/authentication/AttributePrincipalImpl.java
+++ b/cas-client-core/src/main/java/org/apereo/cas/client/authentication/AttributePrincipalImpl.java
@@ -114,4 +114,13 @@ public class AttributePrincipalImpl extends SimplePrincipal implements Attribute
     public Map<String, Object> getAttributes() {
         return this.attributes;
     }
+
+    /**
+     * Returns the proxy granting ticket associated with this principal, if available.
+     *
+     * @return the proxy granting ticket or null
+     */
+    public String getProxyGrantingTicket() {
+        return proxyGrantingTicket;
+    }
 }


### PR DESCRIPTION
A new method has been added to `AttributePrincipalImpl` to retrieve the optional ProxyGrantingTicket.